### PR TITLE
feat: add batch mode for parallel ticket processing

### DIFF
--- a/internal/batch/batch.go
+++ b/internal/batch/batch.go
@@ -1,0 +1,598 @@
+package batch
+
+import (
+	"bufio"
+	"encoding/csv"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/daniil-lyalko/clade/internal/ui"
+)
+
+// TicketStatus represents the current state of a ticket in the batch
+type TicketStatus string
+
+const (
+	StatusQueued  TicketStatus = "queued"
+	StatusRunning TicketStatus = "running"
+	StatusDone    TicketStatus = "done"
+	StatusFailed  TicketStatus = "failed"
+	StatusBlocked TicketStatus = "blocked"
+)
+
+// TicketResult tracks a single ticket's progress
+type TicketResult struct {
+	ID        string       `json:"id"`
+	Repos     []string     `json:"repos,omitempty"` // Repos this ticket spans
+	Status    TicketStatus `json:"status"`
+	Branch    string       `json:"branch,omitempty"`
+	PR        string       `json:"pr,omitempty"`
+	Error     string       `json:"error,omitempty"`
+	StartedAt *time.Time   `json:"started_at,omitempty"`
+	DoneAt    *time.Time   `json:"done_at,omitempty"`
+	LogFile   string       `json:"log_file,omitempty"`
+}
+
+// TicketInput represents a parsed ticket from input (CLI or CSV)
+type TicketInput struct {
+	ID    string
+	Repos []string // Repos this ticket needs (first is primary workdir, rest get --add-dir)
+}
+
+// Duration returns the elapsed time for this ticket
+func (t *TicketResult) Duration() time.Duration {
+	if t.StartedAt == nil {
+		return 0
+	}
+	end := time.Now()
+	if t.DoneAt != nil {
+		end = *t.DoneAt
+	}
+	return end.Sub(*t.StartedAt)
+}
+
+// BatchState persists the state of a batch run
+type BatchState struct {
+	ID          string          `json:"id"`
+	CreatedAt   time.Time       `json:"created_at"`
+	Repo        string          `json:"repo"`
+	Concurrency int             `json:"concurrency"`
+	MaxBudget   float64         `json:"max_budget_usd,omitempty"`
+	Prompt      string          `json:"prompt_template,omitempty"`
+	Tickets     []*TicketResult `json:"tickets"`
+
+	mu      sync.Mutex `json:"-"`
+	baseDir string     `json:"-"`
+
+	// repoMu serializes worktree creation per source repo to avoid git lock conflicts
+	repoMu   map[string]*sync.Mutex `json:"-"`
+	repoMuMu sync.Mutex             `json:"-"`
+}
+
+// BatchDir returns the directory where batch state and logs are stored
+func BatchDir() string {
+	homeDir, _ := os.UserHomeDir()
+	return filepath.Join(homeDir, ".config", "clade", "batches")
+}
+
+// NewBatch creates a new batch with the given tickets
+func NewBatch(inputs []TicketInput, repo string, concurrency int, maxBudget float64, prompt string) *BatchState {
+	id := time.Now().Format("2006-01-02-1504")
+	tickets := make([]*TicketResult, len(inputs))
+	for i, input := range inputs {
+		tickets[i] = &TicketResult{
+			ID:     input.ID,
+			Repos:  input.Repos,
+			Status: StatusQueued,
+		}
+	}
+
+	return &BatchState{
+		ID:          id,
+		CreatedAt:   time.Now(),
+		Repo:        repo,
+		Concurrency: concurrency,
+		MaxBudget:   maxBudget,
+		Prompt:      prompt,
+		Tickets:     tickets,
+	}
+}
+
+// RepoMutex returns a mutex for the given repo path, creating one if needed.
+// This serializes worktree creation per source repo to avoid git lock conflicts.
+func (b *BatchState) RepoMutex(repoPath string) *sync.Mutex {
+	b.repoMuMu.Lock()
+	defer b.repoMuMu.Unlock()
+	if b.repoMu == nil {
+		b.repoMu = make(map[string]*sync.Mutex)
+	}
+	if _, ok := b.repoMu[repoPath]; !ok {
+		b.repoMu[repoPath] = &sync.Mutex{}
+	}
+	return b.repoMu[repoPath]
+}
+
+// Dir returns the directory for this batch
+func (b *BatchState) Dir() string {
+	return filepath.Join(BatchDir(), b.ID)
+}
+
+// Save persists the batch state to disk
+func (b *BatchState) Save() error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	dir := b.Dir()
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return err
+	}
+
+	data, err := json.MarshalIndent(b, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	return os.WriteFile(filepath.Join(dir, "batch.json"), data, 0600)
+}
+
+// LoadBatch reads a batch state from disk
+func LoadBatch(id string) (*BatchState, error) {
+	path := filepath.Join(BatchDir(), id, "batch.json")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	var batch BatchState
+	if err := json.Unmarshal(data, &batch); err != nil {
+		return nil, err
+	}
+	return &batch, nil
+}
+
+// ListBatches returns all batch IDs sorted by most recent
+func ListBatches() ([]string, error) {
+	dir := BatchDir()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	var ids []string
+	for i := len(entries) - 1; i >= 0; i-- {
+		e := entries[i]
+		if e.IsDir() {
+			// Check that batch.json exists
+			if _, err := os.Stat(filepath.Join(dir, e.Name(), "batch.json")); err == nil {
+				ids = append(ids, e.Name())
+			}
+		}
+	}
+	return ids, nil
+}
+
+// UpdateTicket updates a ticket's status thread-safely
+func (b *BatchState) UpdateTicket(id string, fn func(*TicketResult)) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	for _, t := range b.Tickets {
+		if t.ID == id {
+			fn(t)
+			return
+		}
+	}
+}
+
+// WorktreeResult holds the paths created for a ticket
+type WorktreeResult struct {
+	PrimaryPath string   // Main worktree path (workdir for claude)
+	AddDirs     []string // Additional repo worktree paths (--add-dir)
+	Branch      string   // Branch name
+}
+
+// Run executes the batch with the configured concurrency
+func (b *BatchState) Run(repoPath string, createWorktreeFn func(ticket *TicketResult) (*WorktreeResult, error)) error {
+	if err := b.Save(); err != nil {
+		return fmt.Errorf("failed to save initial batch state: %w", err)
+	}
+
+	// Create log directory
+	logDir := filepath.Join(b.Dir(), "logs")
+	if err := os.MkdirAll(logDir, 0755); err != nil {
+		return fmt.Errorf("failed to create log directory: %w", err)
+	}
+
+	ui.Header("Starting batch %s", b.ID)
+	ui.KeyValue("Tickets", fmt.Sprintf("%d", len(b.Tickets)))
+	ui.KeyValue("Concurrency", fmt.Sprintf("%d", b.Concurrency))
+	ui.KeyValue("Repo", b.Repo)
+	fmt.Println()
+
+	// Build work queue
+	work := make(chan *TicketResult, len(b.Tickets))
+	for _, t := range b.Tickets {
+		work <- t
+	}
+	close(work)
+
+	var wg sync.WaitGroup
+	for i := 0; i < b.Concurrency; i++ {
+		wg.Add(1)
+		go func(workerID int) {
+			defer wg.Done()
+			for ticket := range work {
+				b.processTicket(ticket, logDir, createWorktreeFn)
+			}
+		}(i)
+	}
+
+	wg.Wait()
+
+	// Final status
+	b.Save()
+	fmt.Println()
+	b.PrintStatus()
+
+	return nil
+}
+
+// processTicket handles a single ticket: create worktree(s), run claude, track result
+func (b *BatchState) processTicket(ticket *TicketResult, logDir string, createWorktreeFn func(*TicketResult) (*WorktreeResult, error)) {
+	now := time.Now()
+	b.UpdateTicket(ticket.ID, func(t *TicketResult) {
+		t.Status = StatusRunning
+		t.StartedAt = &now
+	})
+	b.Save()
+
+	ui.Info("[%s] Starting...", ticket.ID)
+
+	// Step 1: Create worktree(s)
+	wtResult, err := createWorktreeFn(ticket)
+	if err != nil {
+		b.markFailed(ticket.ID, fmt.Sprintf("worktree creation failed: %v", err))
+		return
+	}
+
+	b.UpdateTicket(ticket.ID, func(t *TicketResult) {
+		t.Branch = wtResult.Branch
+	})
+	b.Save()
+
+	if len(wtResult.AddDirs) > 0 {
+		ui.Info("[%s] Worktrees ready: %s + %d additional repos", ticket.ID, wtResult.PrimaryPath, len(wtResult.AddDirs))
+	} else {
+		ui.Info("[%s] Worktree ready at %s", ticket.ID, wtResult.PrimaryPath)
+	}
+
+	// Step 2: Run Claude Code in non-interactive mode
+	logFile := filepath.Join(logDir, ticket.ID+".log")
+	b.UpdateTicket(ticket.ID, func(t *TicketResult) {
+		t.LogFile = logFile
+	})
+
+	prompt := b.buildPrompt(ticket.ID, wtResult.Branch)
+
+	args := []string{
+		"-p", prompt,
+		"--permission-mode", "bypassPermissions",
+	}
+
+	// Add additional repo directories
+	for _, dir := range wtResult.AddDirs {
+		args = append(args, "--add-dir", dir)
+	}
+
+	if b.MaxBudget > 0 {
+		args = append(args, "--max-budget-usd", fmt.Sprintf("%.2f", b.MaxBudget))
+	}
+
+	cmd := exec.Command("claude", args...)
+	cmd.Dir = wtResult.PrimaryPath
+
+	// Capture output to log file
+	logF, err := os.Create(logFile)
+	if err != nil {
+		b.markFailed(ticket.ID, fmt.Sprintf("failed to create log file: %v", err))
+		return
+	}
+	defer logF.Close()
+
+	cmd.Stdout = logF
+	cmd.Stderr = logF
+
+	ui.Info("[%s] Running claude...", ticket.ID)
+
+	err = cmd.Run()
+	doneAt := time.Now()
+
+	if err != nil {
+		b.markFailed(ticket.ID, fmt.Sprintf("claude exited with error: %v", err))
+		return
+	}
+
+	// Check log for PR URL
+	prURL := extractPRURL(logFile)
+
+	b.UpdateTicket(ticket.ID, func(t *TicketResult) {
+		t.Status = StatusDone
+		t.DoneAt = &doneAt
+		if prURL != "" {
+			t.PR = prURL
+		}
+	})
+	b.Save()
+
+	duration := doneAt.Sub(*ticket.StartedAt).Round(time.Second)
+	ui.Success("[%s] Done (%s)", ticket.ID, duration)
+}
+
+func (b *BatchState) markFailed(ticketID, errMsg string) {
+	now := time.Now()
+	b.UpdateTicket(ticketID, func(t *TicketResult) {
+		t.Status = StatusFailed
+		t.Error = errMsg
+		t.DoneAt = &now
+	})
+	b.Save()
+	ui.Error("[%s] Failed: %s", ticketID, errMsg)
+}
+
+func (b *BatchState) buildPrompt(ticketID, branch string) string {
+	if b.Prompt != "" {
+		// Replace placeholders in custom prompt
+		prompt := strings.ReplaceAll(b.Prompt, "{TICKET_ID}", ticketID)
+		prompt = strings.ReplaceAll(prompt, "{BRANCH}", branch)
+		return prompt
+	}
+
+	// Find repos for this ticket to customize the prompt
+	var ticketRepos []string
+	for _, t := range b.Tickets {
+		if t.ID == ticketID {
+			ticketRepos = t.Repos
+			break
+		}
+	}
+
+	multiRepoNote := ""
+	if len(ticketRepos) > 1 {
+		multiRepoNote = fmt.Sprintf(`
+Note: This ticket spans multiple repositories. You have access to all of them
+via --add-dir. Make changes in each repo as needed. Commit and push the branch
+"%s" in EACH repo that has changes. Create a PR for each repo that has changes.
+`, branch)
+	}
+
+	return fmt.Sprintf(`You are working on Jira ticket %s.%s
+
+Step 1 — Understand the ticket:
+  Use the Jira MCP tools (getJiraIssue) to fetch %s.
+  Read the title, description, acceptance criteria, and any linked tickets.
+  A title alone is often enough if it clearly describes what to do
+  (e.g., "Add phone validation to contact form" is actionable).
+
+Step 2 — Evaluate if you can proceed:
+  You need to be able to determine:
+    - WHAT needs to change (which feature, behavior, or bug)
+    - WHERE in the codebase it lives (search to find relevant files)
+  If BOTH are clear, proceed to Step 3.
+  If the ticket is truly ambiguous (you cannot determine what or where),
+  go to Step 2b.
+
+Step 2b — Blocked ticket:
+  Add a comment to the Jira ticket using the MCP tools:
+    "🤖 Automated: Unable to implement — this ticket needs more detail.
+     Missing: [explain what is unclear or missing]
+     Please update the ticket description and re-queue."
+  Then STOP. Do not write any code. Exit immediately.
+
+Step 3 — Implement:
+  1. Analyze the codebase to understand the relevant code and patterns
+  2. Implement the solution following existing code style and conventions
+  3. Run any relevant tests (npm test, go test, etc.) and fix failures
+  4. Commit your changes with a descriptive message referencing %s
+  5. Push the branch: git push -u origin %s
+  6. Create a PR: gh pr create --title "[%s] <brief description>" --body "<summary of changes>"
+  7. Add a comment to the Jira ticket with the PR link
+
+Important:
+- Only push to branch %s — never to main/master
+- Follow existing code style and patterns
+- Prefer the simplest, most straightforward solution
+- If tests exist for the area you changed, make sure they pass`, ticketID, multiRepoNote, ticketID, ticketID, branch, ticketID, branch)
+}
+
+// PrintStatus displays the current batch status
+func (b *BatchState) PrintStatus() {
+	ui.Header("Batch %s", b.ID)
+	ui.KeyValue("Repo", b.Repo)
+	ui.KeyValue("Workers", fmt.Sprintf("%d", b.Concurrency))
+
+	var queued, running, done, failed, blocked int
+	fmt.Println()
+	for _, t := range b.Tickets {
+		switch t.Status {
+		case StatusQueued:
+			queued++
+			fmt.Printf("  %s %s  %s\n", ui.Dim("○"), ui.Cyan(t.ID), ui.Dim("queued"))
+		case StatusRunning:
+			running++
+			elapsed := t.Duration().Round(time.Second)
+			fmt.Printf("  %s %s  %s  %s\n", ui.Yellow("●"), ui.Cyan(t.ID), ui.Yellow("running"), ui.Dim(fmt.Sprintf("(%s elapsed)", elapsed)))
+		case StatusDone:
+			done++
+			duration := t.Duration().Round(time.Second)
+			prInfo := ""
+			if t.PR != "" {
+				prInfo = "  " + t.PR
+			}
+			fmt.Printf("  %s %s  %s  %s%s\n", ui.Green("✓"), ui.Cyan(t.ID), ui.Green("done"), ui.Dim(fmt.Sprintf("(%s)", duration)), prInfo)
+		case StatusBlocked:
+			blocked++
+			errInfo := t.Error
+			if errInfo == "" {
+				errInfo = "needs more detail"
+			}
+			fmt.Printf("  %s %s  %s  %s\n", ui.Yellow("⚠"), ui.Cyan(t.ID), ui.Yellow("blocked"), ui.Dim(errInfo))
+		case StatusFailed:
+			failed++
+			fmt.Printf("  %s %s  %s  %s\n", ui.Red("✗"), ui.Cyan(t.ID), ui.Red("failed"), ui.Dim(t.Error))
+		}
+	}
+
+	fmt.Println()
+	summary := fmt.Sprintf("%d done, %d running, %d queued", done, running, queued)
+	if blocked > 0 {
+		summary += fmt.Sprintf(", %d blocked", blocked)
+	}
+	if failed > 0 {
+		summary += fmt.Sprintf(", %d failed", failed)
+	}
+	ui.Detail("Summary: %s", summary)
+}
+
+// extractPRURL scans a log file for a GitHub PR URL
+func extractPRURL(logFile string) string {
+	f, err := os.Open(logFile)
+	if err != nil {
+		return ""
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := scanner.Text()
+		// Look for github.com PR URLs
+		if idx := strings.Index(line, "https://github.com/"); idx != -1 {
+			url := line[idx:]
+			// Trim to just the URL
+			if end := strings.IndexAny(url, " \t\n\"'`])}"); end != -1 {
+				url = url[:end]
+			}
+			if strings.Contains(url, "/pull/") {
+				return url
+			}
+		}
+	}
+	return ""
+}
+
+// ParseTicketsFromCSV reads ticket IDs from a CSV file
+// Supports:
+//   - One ID per line (no header)
+//   - Header row with "ticket"/"id"/"key" column and optional "repo" column
+func ParseTicketsFromCSV(path string) ([]TicketInput, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	reader := csv.NewReader(f)
+	reader.FieldsPerRecord = -1 // Allow variable fields
+	reader.TrimLeadingSpace = true
+
+	records, err := reader.ReadAll()
+	if err != nil {
+		return nil, err
+	}
+
+	if len(records) == 0 {
+		return nil, fmt.Errorf("empty CSV file")
+	}
+
+	// Check if first row is a header
+	ticketCol := 0
+	reposCol := -1
+	hasHeader := false
+	firstRow := records[0]
+	for i, col := range firstRow {
+		lower := strings.ToLower(strings.TrimSpace(col))
+		switch lower {
+		case "ticket", "id", "key", "ticket_id":
+			ticketCol = i
+			hasHeader = true
+		case "repo", "repos", "repository", "repositories":
+			reposCol = i
+			hasHeader = true
+		}
+	}
+
+	var tickets []TicketInput
+	startRow := 0
+	if hasHeader {
+		startRow = 1
+	}
+
+	for _, row := range records[startRow:] {
+		if ticketCol >= len(row) {
+			continue
+		}
+		id := strings.TrimSpace(row[ticketCol])
+		if id == "" {
+			continue
+		}
+		input := TicketInput{ID: id}
+		if reposCol >= 0 && reposCol < len(row) {
+			reposStr := strings.TrimSpace(row[reposCol])
+			if reposStr != "" {
+				for _, r := range strings.Split(reposStr, ",") {
+					r = strings.TrimSpace(r)
+					if r != "" {
+						input.Repos = append(input.Repos, r)
+					}
+				}
+			}
+		}
+		tickets = append(tickets, input)
+	}
+
+	if len(tickets) == 0 {
+		return nil, fmt.Errorf("no ticket IDs found in CSV")
+	}
+
+	return tickets, nil
+}
+
+// ParseTicketsFromFile reads ticket IDs from a plain text file (one per line) or CSV
+func ParseTicketsFromFile(path string) ([]TicketInput, error) {
+	// Try CSV first
+	if strings.HasSuffix(strings.ToLower(path), ".csv") {
+		return ParseTicketsFromCSV(path)
+	}
+
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	var tickets []TicketInput
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line != "" && !strings.HasPrefix(line, "#") {
+			tickets = append(tickets, TicketInput{ID: line})
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+
+	if len(tickets) == 0 {
+		return nil, fmt.Errorf("no ticket IDs found in file")
+	}
+
+	return tickets, nil
+}

--- a/internal/batch/batch.go
+++ b/internal/batch/batch.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"sync"
 	"time"
@@ -487,10 +488,23 @@ func extractPRURL(logFile string) string {
 	return ""
 }
 
+// repoNamePattern matches strings that look like repository names:
+// short, no spaces, only alphanumeric chars plus hyphens and underscores.
+var repoNamePattern = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9_-]*$`)
+
+// looksLikeRepoName returns true if s looks like a repository name rather than
+// free-form text (e.g. evidence or descriptions). Repo names are short, contain
+// no spaces, and consist of alphanumeric characters, hyphens, and underscores.
+func looksLikeRepoName(s string) bool {
+	s = strings.TrimSpace(s)
+	return len(s) > 0 && len(s) < 30 && repoNamePattern.MatchString(s)
+}
+
 // ParseTicketsFromCSV reads ticket IDs from a CSV file
 // Supports:
 //   - One ID per line (no header)
 //   - Header row with "ticket"/"id"/"key" column and optional "repo" column
+//   - Multi-repo values both quoted ("repo-a,repo-b") and unquoted (repo-a,repo-b)
 func ParseTicketsFromCSV(path string) ([]TicketInput, error) {
 	f, err := os.Open(path)
 	if err != nil {
@@ -546,11 +560,23 @@ func ParseTicketsFromCSV(path string) ([]TicketInput, error) {
 		if reposCol >= 0 && reposCol < len(row) {
 			reposStr := strings.TrimSpace(row[reposCol])
 			if reposStr != "" {
+				// Handle quoted multi-repo values (e.g. "repo-a,repo-b" parsed as one field)
 				for _, r := range strings.Split(reposStr, ",") {
 					r = strings.TrimSpace(r)
 					if r != "" {
 						input.Repos = append(input.Repos, r)
 					}
+				}
+			}
+			// Handle unquoted multi-repo values: the CSV reader splits
+			// "TICKET,repo-a,repo-b,some evidence" into separate columns.
+			// Consume subsequent columns that look like repo names.
+			for i := reposCol + 1; i < len(row); i++ {
+				val := strings.TrimSpace(row[i])
+				if looksLikeRepoName(val) {
+					input.Repos = append(input.Repos, val)
+				} else {
+					break
 				}
 			}
 		}

--- a/internal/batch/batch_test.go
+++ b/internal/batch/batch_test.go
@@ -1,0 +1,440 @@
+package batch
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewBatch(t *testing.T) {
+	inputs := []TicketInput{
+		{ID: "PROJ-1"},
+		{ID: "PROJ-2", Repos: []string{"/repo1", "/repo2"}},
+	}
+
+	b := NewBatch(inputs, "my-repo", 3, 5.0, "")
+
+	assert.NotEmpty(t, b.ID)
+	assert.Equal(t, "my-repo", b.Repo)
+	assert.Equal(t, 3, b.Concurrency)
+	assert.Equal(t, 5.0, b.MaxBudget)
+	assert.Len(t, b.Tickets, 2)
+
+	assert.Equal(t, "PROJ-1", b.Tickets[0].ID)
+	assert.Equal(t, StatusQueued, b.Tickets[0].Status)
+	assert.Empty(t, b.Tickets[0].Repos)
+
+	assert.Equal(t, "PROJ-2", b.Tickets[1].ID)
+	assert.Equal(t, []string{"/repo1", "/repo2"}, b.Tickets[1].Repos)
+}
+
+func TestBatchSaveAndLoad(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Override BatchDir
+	origHome := os.Getenv("HOME")
+	os.Setenv("HOME", tmpDir)
+	defer os.Setenv("HOME", origHome)
+
+	inputs := []TicketInput{{ID: "PROJ-100"}}
+	b := NewBatch(inputs, "test-repo", 2, 0, "custom prompt")
+	b.ID = "test-batch-001"
+
+	err := b.Save()
+	require.NoError(t, err)
+
+	// Verify file exists
+	batchFile := filepath.Join(tmpDir, ".config", "clade", "batches", "test-batch-001", "batch.json")
+	_, err = os.Stat(batchFile)
+	require.NoError(t, err)
+
+	// Load it back
+	loaded, err := LoadBatch("test-batch-001")
+	require.NoError(t, err)
+
+	assert.Equal(t, "test-batch-001", loaded.ID)
+	assert.Equal(t, "test-repo", loaded.Repo)
+	assert.Equal(t, 2, loaded.Concurrency)
+	assert.Equal(t, "custom prompt", loaded.Prompt)
+	assert.Len(t, loaded.Tickets, 1)
+	assert.Equal(t, "PROJ-100", loaded.Tickets[0].ID)
+	assert.Equal(t, StatusQueued, loaded.Tickets[0].Status)
+}
+
+func TestListBatches(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	origHome := os.Getenv("HOME")
+	os.Setenv("HOME", tmpDir)
+	defer os.Setenv("HOME", origHome)
+
+	// No batches yet
+	ids, err := ListBatches()
+	require.NoError(t, err)
+	assert.Empty(t, ids)
+
+	// Create two batches
+	b1 := NewBatch([]TicketInput{{ID: "T-1"}}, "repo", 1, 0, "")
+	b1.ID = "2026-01-01-0900"
+	require.NoError(t, b1.Save())
+
+	b2 := NewBatch([]TicketInput{{ID: "T-2"}}, "repo", 1, 0, "")
+	b2.ID = "2026-01-02-0900"
+	require.NoError(t, b2.Save())
+
+	ids, err = ListBatches()
+	require.NoError(t, err)
+	assert.Len(t, ids, 2)
+	// Most recent first
+	assert.Equal(t, "2026-01-02-0900", ids[0])
+	assert.Equal(t, "2026-01-01-0900", ids[1])
+}
+
+func TestUpdateTicket(t *testing.T) {
+	b := NewBatch([]TicketInput{{ID: "T-1"}, {ID: "T-2"}}, "repo", 1, 0, "")
+
+	b.UpdateTicket("T-1", func(tr *TicketResult) {
+		tr.Status = StatusRunning
+		now := time.Now()
+		tr.StartedAt = &now
+	})
+
+	assert.Equal(t, StatusRunning, b.Tickets[0].Status)
+	assert.NotNil(t, b.Tickets[0].StartedAt)
+	// T-2 unchanged
+	assert.Equal(t, StatusQueued, b.Tickets[1].Status)
+}
+
+func TestUpdateTicket_NonExistent(t *testing.T) {
+	b := NewBatch([]TicketInput{{ID: "T-1"}}, "repo", 1, 0, "")
+
+	// Should not panic
+	b.UpdateTicket("T-999", func(tr *TicketResult) {
+		tr.Status = StatusDone
+	})
+
+	assert.Equal(t, StatusQueued, b.Tickets[0].Status)
+}
+
+func TestTicketResult_Duration(t *testing.T) {
+	// Not started
+	tr := &TicketResult{ID: "T-1", Status: StatusQueued}
+	assert.Equal(t, time.Duration(0), tr.Duration())
+
+	// Running
+	start := time.Now().Add(-5 * time.Second)
+	tr.StartedAt = &start
+	tr.Status = StatusRunning
+	assert.InDelta(t, 5*time.Second, tr.Duration(), float64(500*time.Millisecond))
+
+	// Done
+	end := start.Add(10 * time.Second)
+	tr.DoneAt = &end
+	tr.Status = StatusDone
+	assert.Equal(t, 10*time.Second, tr.Duration())
+}
+
+func TestBuildPrompt_Default(t *testing.T) {
+	b := NewBatch([]TicketInput{{ID: "PROJ-1"}}, "repo", 1, 0, "")
+
+	prompt := b.buildPrompt("PROJ-1", "feat/PROJ-1")
+
+	assert.Contains(t, prompt, "PROJ-1")
+	assert.Contains(t, prompt, "feat/PROJ-1")
+	assert.Contains(t, prompt, "Step 1")
+	assert.Contains(t, prompt, "getJiraIssue")
+}
+
+func TestBuildPrompt_MultiRepo(t *testing.T) {
+	b := NewBatch([]TicketInput{{ID: "PROJ-1", Repos: []string{"/repo1", "/repo2"}}}, "repo", 1, 0, "")
+
+	prompt := b.buildPrompt("PROJ-1", "feat/PROJ-1")
+
+	assert.Contains(t, prompt, "multiple repositories")
+	assert.Contains(t, prompt, "--add-dir")
+	assert.Contains(t, prompt, "EACH repo")
+}
+
+func TestBuildPrompt_Custom(t *testing.T) {
+	b := NewBatch([]TicketInput{{ID: "PROJ-1"}}, "repo", 1, 0, "Fix {TICKET_ID} on branch {BRANCH} now")
+
+	prompt := b.buildPrompt("PROJ-1", "feat/PROJ-1")
+
+	assert.Equal(t, "Fix PROJ-1 on branch feat/PROJ-1 now", prompt)
+}
+
+func TestBuildPrompt_CustomIgnoresDefault(t *testing.T) {
+	b := NewBatch([]TicketInput{{ID: "PROJ-1", Repos: []string{"/r1", "/r2"}}}, "repo", 1, 0, "Just do {TICKET_ID}")
+
+	prompt := b.buildPrompt("PROJ-1", "feat/PROJ-1")
+
+	// Custom prompt should NOT include multi-repo note or default steps
+	assert.Equal(t, "Just do PROJ-1", prompt)
+	assert.NotContains(t, prompt, "multiple repositories")
+	assert.NotContains(t, prompt, "Step 1")
+}
+
+func TestParseTicketsFromCSV_WithHeader(t *testing.T) {
+	tmpDir := t.TempDir()
+	csvPath := filepath.Join(tmpDir, "tickets.csv")
+
+	content := `ticket,repos
+PROJ-1,"repo-a,repo-b"
+PROJ-2,repo-a
+PROJ-3,
+`
+	require.NoError(t, os.WriteFile(csvPath, []byte(content), 0644))
+
+	tickets, err := ParseTicketsFromCSV(csvPath)
+	require.NoError(t, err)
+
+	assert.Len(t, tickets, 3)
+
+	assert.Equal(t, "PROJ-1", tickets[0].ID)
+	assert.Equal(t, []string{"repo-a", "repo-b"}, tickets[0].Repos)
+
+	assert.Equal(t, "PROJ-2", tickets[1].ID)
+	assert.Equal(t, []string{"repo-a"}, tickets[1].Repos)
+
+	assert.Equal(t, "PROJ-3", tickets[2].ID)
+	assert.Empty(t, tickets[2].Repos)
+}
+
+func TestParseTicketsFromCSV_NoHeader(t *testing.T) {
+	tmpDir := t.TempDir()
+	csvPath := filepath.Join(tmpDir, "tickets.csv")
+
+	content := `PROJ-1
+PROJ-2
+PROJ-3
+`
+	require.NoError(t, os.WriteFile(csvPath, []byte(content), 0644))
+
+	tickets, err := ParseTicketsFromCSV(csvPath)
+	require.NoError(t, err)
+
+	assert.Len(t, tickets, 3)
+	assert.Equal(t, "PROJ-1", tickets[0].ID)
+	assert.Empty(t, tickets[0].Repos)
+}
+
+func TestParseTicketsFromCSV_AlternateHeaders(t *testing.T) {
+	tests := []struct {
+		name    string
+		header  string
+	}{
+		{"id header", "id,repository"},
+		{"key header", "key,repos"},
+		{"ticket_id header", "ticket_id,repositories"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			csvPath := filepath.Join(tmpDir, "tickets.csv")
+
+			content := tt.header + "\nPROJ-1,repo-a\n"
+			require.NoError(t, os.WriteFile(csvPath, []byte(content), 0644))
+
+			tickets, err := ParseTicketsFromCSV(csvPath)
+			require.NoError(t, err)
+
+			assert.Len(t, tickets, 1)
+			assert.Equal(t, "PROJ-1", tickets[0].ID)
+			assert.Equal(t, []string{"repo-a"}, tickets[0].Repos)
+		})
+	}
+}
+
+func TestParseTicketsFromCSV_Empty(t *testing.T) {
+	tmpDir := t.TempDir()
+	csvPath := filepath.Join(tmpDir, "tickets.csv")
+
+	require.NoError(t, os.WriteFile(csvPath, []byte(""), 0644))
+
+	_, err := ParseTicketsFromCSV(csvPath)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "empty CSV")
+}
+
+func TestParseTicketsFromCSV_HeaderOnly(t *testing.T) {
+	tmpDir := t.TempDir()
+	csvPath := filepath.Join(tmpDir, "tickets.csv")
+
+	require.NoError(t, os.WriteFile(csvPath, []byte("ticket,repos\n"), 0644))
+
+	_, err := ParseTicketsFromCSV(csvPath)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "no ticket IDs")
+}
+
+func TestParseTicketsFromFile_TextFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	txtPath := filepath.Join(tmpDir, "tickets.txt")
+
+	content := `PROJ-1
+# this is a comment
+PROJ-2
+
+PROJ-3
+`
+	require.NoError(t, os.WriteFile(txtPath, []byte(content), 0644))
+
+	tickets, err := ParseTicketsFromFile(txtPath)
+	require.NoError(t, err)
+
+	assert.Len(t, tickets, 3)
+	assert.Equal(t, "PROJ-1", tickets[0].ID)
+	assert.Equal(t, "PROJ-2", tickets[1].ID)
+	assert.Equal(t, "PROJ-3", tickets[2].ID)
+}
+
+func TestParseTicketsFromFile_CSVExtension(t *testing.T) {
+	tmpDir := t.TempDir()
+	csvPath := filepath.Join(tmpDir, "tickets.csv")
+
+	content := "ticket\nPROJ-1\nPROJ-2\n"
+	require.NoError(t, os.WriteFile(csvPath, []byte(content), 0644))
+
+	tickets, err := ParseTicketsFromFile(csvPath)
+	require.NoError(t, err)
+
+	assert.Len(t, tickets, 2)
+}
+
+func TestParseTicketsFromFile_NotFound(t *testing.T) {
+	_, err := ParseTicketsFromFile("/nonexistent/file.txt")
+	assert.Error(t, err)
+}
+
+func TestExtractPRURL(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	tests := []struct {
+		name     string
+		content  string
+		expected string
+	}{
+		{
+			name:     "PR URL in output",
+			content:  "Creating PR...\nhttps://github.com/org/repo/pull/123\nDone!",
+			expected: "https://github.com/org/repo/pull/123",
+		},
+		{
+			name:     "PR URL with trailing space",
+			content:  "PR: https://github.com/org/repo/pull/456 created",
+			expected: "https://github.com/org/repo/pull/456",
+		},
+		{
+			name:     "No PR URL",
+			content:  "Just some output\nNo PR here",
+			expected: "",
+		},
+		{
+			name:     "GitHub URL but not a PR",
+			content:  "See https://github.com/org/repo/issues/789",
+			expected: "",
+		},
+		{
+			name:     "PR URL in quotes",
+			content:  `Created "https://github.com/org/repo/pull/42" successfully`,
+			expected: "https://github.com/org/repo/pull/42",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logFile := filepath.Join(tmpDir, tt.name+".log")
+			require.NoError(t, os.WriteFile(logFile, []byte(tt.content), 0644))
+
+			result := extractPRURL(logFile)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestExtractPRURL_FileNotFound(t *testing.T) {
+	result := extractPRURL("/nonexistent/file.log")
+	assert.Empty(t, result)
+}
+
+func TestRepoMutex(t *testing.T) {
+	b := NewBatch([]TicketInput{{ID: "T-1"}}, "repo", 1, 0, "")
+
+	mu1 := b.RepoMutex("/repo/a")
+	mu2 := b.RepoMutex("/repo/b")
+	mu1Again := b.RepoMutex("/repo/a")
+
+	// Same repo returns same mutex
+	assert.Same(t, mu1, mu1Again)
+	// Different repos return different mutexes
+	assert.NotSame(t, mu1, mu2)
+}
+
+func TestRepoMutex_ConcurrentAccess(t *testing.T) {
+	b := NewBatch([]TicketInput{{ID: "T-1"}}, "repo", 1, 0, "")
+
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			repo := "/repo/a"
+			if n%2 == 0 {
+				repo = "/repo/b"
+			}
+			mu := b.RepoMutex(repo)
+			mu.Lock()
+			mu.Unlock()
+		}(i)
+	}
+	wg.Wait()
+}
+
+func TestRun_WithMockClaude(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	origHome := os.Getenv("HOME")
+	os.Setenv("HOME", tmpDir)
+	defer os.Setenv("HOME", origHome)
+
+	inputs := []TicketInput{{ID: "T-1"}, {ID: "T-2"}}
+	b := NewBatch(inputs, "test-repo", 2, 0, "")
+
+	createFn := func(ticket *TicketResult) (*WorktreeResult, error) {
+		wtDir := filepath.Join(tmpDir, "worktrees", ticket.ID)
+		os.MkdirAll(wtDir, 0755)
+		return &WorktreeResult{
+			PrimaryPath: wtDir,
+			Branch:      "feat/" + ticket.ID,
+		}, nil
+	}
+
+	// This will fail because "claude" binary doesn't exist in test,
+	// but it validates the run loop, state management, and concurrency
+	err := b.Run(tmpDir, createFn)
+	assert.NoError(t, err)
+
+	// Both tickets should have been processed (failed since no claude binary)
+	for _, ticket := range b.Tickets {
+		assert.Equal(t, StatusFailed, ticket.Status)
+		assert.NotNil(t, ticket.StartedAt)
+		assert.NotNil(t, ticket.DoneAt)
+		assert.Contains(t, ticket.Error, "claude exited with error")
+	}
+
+	// Batch state should have been saved
+	loaded, err := LoadBatch(b.ID)
+	require.NoError(t, err)
+	assert.Len(t, loaded.Tickets, 2)
+}
+
+func TestBatchDir(t *testing.T) {
+	dir := BatchDir()
+	assert.Contains(t, dir, ".config/clade/batches")
+}

--- a/internal/batch/batch_test.go
+++ b/internal/batch/batch_test.go
@@ -251,6 +251,130 @@ func TestParseTicketsFromCSV_AlternateHeaders(t *testing.T) {
 	}
 }
 
+func TestParseTicketsFromCSV_QuotedMultiRepo(t *testing.T) {
+	tmpDir := t.TempDir()
+	csvPath := filepath.Join(tmpDir, "tickets.csv")
+
+	content := `ticket,repos,evidence
+TICKET-1,"repo-a,repo-b",some evidence text here
+`
+	require.NoError(t, os.WriteFile(csvPath, []byte(content), 0644))
+
+	tickets, err := ParseTicketsFromCSV(csvPath)
+	require.NoError(t, err)
+
+	assert.Len(t, tickets, 1)
+	assert.Equal(t, "TICKET-1", tickets[0].ID)
+	assert.Equal(t, []string{"repo-a", "repo-b"}, tickets[0].Repos)
+}
+
+func TestParseTicketsFromCSV_UnquotedMultiRepo(t *testing.T) {
+	tmpDir := t.TempDir()
+	csvPath := filepath.Join(tmpDir, "tickets.csv")
+
+	content := `ticket,repos
+TICKET-1,repo-a,repo-b,some evidence text here
+`
+	require.NoError(t, os.WriteFile(csvPath, []byte(content), 0644))
+
+	tickets, err := ParseTicketsFromCSV(csvPath)
+	require.NoError(t, err)
+
+	assert.Len(t, tickets, 1)
+	assert.Equal(t, "TICKET-1", tickets[0].ID)
+	assert.Equal(t, []string{"repo-a", "repo-b"}, tickets[0].Repos)
+}
+
+func TestParseTicketsFromCSV_SingleRepo(t *testing.T) {
+	tmpDir := t.TempDir()
+	csvPath := filepath.Join(tmpDir, "tickets.csv")
+
+	content := `ticket,repos
+TICKET-1,repo-a,some evidence text here
+`
+	require.NoError(t, os.WriteFile(csvPath, []byte(content), 0644))
+
+	tickets, err := ParseTicketsFromCSV(csvPath)
+	require.NoError(t, err)
+
+	assert.Len(t, tickets, 1)
+	assert.Equal(t, "TICKET-1", tickets[0].ID)
+	assert.Equal(t, []string{"repo-a"}, tickets[0].Repos)
+}
+
+func TestParseTicketsFromCSV_SingleRepoNoEvidence(t *testing.T) {
+	tmpDir := t.TempDir()
+	csvPath := filepath.Join(tmpDir, "tickets.csv")
+
+	content := `ticket,repos
+TICKET-1,repo-a
+`
+	require.NoError(t, os.WriteFile(csvPath, []byte(content), 0644))
+
+	tickets, err := ParseTicketsFromCSV(csvPath)
+	require.NoError(t, err)
+
+	assert.Len(t, tickets, 1)
+	assert.Equal(t, "TICKET-1", tickets[0].ID)
+	assert.Equal(t, []string{"repo-a"}, tickets[0].Repos)
+}
+
+func TestParseTicketsFromCSV_ThreeReposUnquoted(t *testing.T) {
+	tmpDir := t.TempDir()
+	csvPath := filepath.Join(tmpDir, "tickets.csv")
+
+	content := `ticket,repos
+TICKET-1,repo-a,repo-b,repo-c,some evidence text here
+`
+	require.NoError(t, os.WriteFile(csvPath, []byte(content), 0644))
+
+	tickets, err := ParseTicketsFromCSV(csvPath)
+	require.NoError(t, err)
+
+	assert.Len(t, tickets, 1)
+	assert.Equal(t, "TICKET-1", tickets[0].ID)
+	assert.Equal(t, []string{"repo-a", "repo-b", "repo-c"}, tickets[0].Repos)
+}
+
+func TestParseTicketsFromCSV_RealWorldUnquoted(t *testing.T) {
+	// Simulates the real-world case from the bug report
+	tmpDir := t.TempDir()
+	csvPath := filepath.Join(tmpDir, "tickets.csv")
+
+	content := `ticket,repos
+SALESPRO-6493,leap-360,leap_one_server,E2E smoke test: Corp Admin Copy Price Guide
+SALESPRO-7000,salespro-ios,Fix login button
+`
+	require.NoError(t, os.WriteFile(csvPath, []byte(content), 0644))
+
+	tickets, err := ParseTicketsFromCSV(csvPath)
+	require.NoError(t, err)
+
+	assert.Len(t, tickets, 2)
+
+	assert.Equal(t, "SALESPRO-6493", tickets[0].ID)
+	assert.Equal(t, []string{"leap-360", "leap_one_server"}, tickets[0].Repos)
+
+	assert.Equal(t, "SALESPRO-7000", tickets[1].ID)
+	assert.Equal(t, []string{"salespro-ios"}, tickets[1].Repos)
+}
+
+func TestLooksLikeRepoName(t *testing.T) {
+	// Should match repo names
+	assert.True(t, looksLikeRepoName("leap-360"))
+	assert.True(t, looksLikeRepoName("leap_one_server"))
+	assert.True(t, looksLikeRepoName("salespro-ios"))
+	assert.True(t, looksLikeRepoName("repo-a"))
+	assert.True(t, looksLikeRepoName("doc-editor-two"))
+
+	// Should NOT match evidence text
+	assert.False(t, looksLikeRepoName("some evidence text here"))
+	assert.False(t, looksLikeRepoName("E2E smoke test: Corp Admin Copy Price Guide"))
+	assert.False(t, looksLikeRepoName("Fix login button"))
+	assert.False(t, looksLikeRepoName(""))
+	assert.False(t, looksLikeRepoName("   "))
+}
+
 func TestParseTicketsFromCSV_Empty(t *testing.T) {
 	tmpDir := t.TempDir()
 	csvPath := filepath.Join(tmpDir, "tickets.csv")

--- a/internal/cmd/batch.go
+++ b/internal/cmd/batch.go
@@ -1,0 +1,521 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/daniil-lyalko/clade/internal/batch"
+	"github.com/daniil-lyalko/clade/internal/config"
+	"github.com/daniil-lyalko/clade/internal/git"
+	"github.com/daniil-lyalko/clade/internal/ui"
+	"github.com/spf13/cobra"
+)
+
+var (
+	batchFileFlag        string
+	batchConcurrencyFlag int
+	batchRepoFlag        string
+	batchBudgetFlag      float64
+	batchPromptFlag      string
+	batchTypeFlag        string
+	batchFromFlag        string
+	batchDryRunFlag      bool
+	batchProjectFlag     bool
+)
+
+var batchCmd = &cobra.Command{
+	Use:   "batch [ticket-ids...]",
+	Short: "Run multiple tickets in parallel with autonomous Claude agents",
+	Long: `Process multiple Jira tickets concurrently. Each ticket gets its own
+worktree and an autonomous Claude Code agent that fetches the ticket,
+implements the solution, and creates a PR.
+
+Input methods:
+  clade batch PROJ-123 PROJ-456 PROJ-789       # Direct ticket IDs
+  clade batch --file tickets.csv                # From CSV file
+  clade batch --file tickets.txt                # From text file (one per line)
+
+CSV files can have a header row with "ticket", "id", or "key" column,
+or just one ticket ID per line.
+
+Examples:
+  clade batch SALESPRO-1234 SALESPRO-1235 --concurrency 2
+  clade batch --file sprint-tickets.csv --concurrency 3 --repo leap-360
+  clade batch PROJ-100 --budget 5.00 --type bug
+  clade batch PROJ-100 --prompt "Fix the bug described in {TICKET_ID}"`,
+	Args: cobra.ArbitraryArgs,
+	RunE: runBatch,
+}
+
+var batchStatusCmd = &cobra.Command{
+	Use:   "status [batch-id]",
+	Short: "Show status of batch runs",
+	Long: `Show the status of batch runs. Without arguments, lists all batches.
+With a batch ID, shows detailed status for that batch.`,
+	Args: cobra.MaximumNArgs(1),
+	RunE: runBatchStatus,
+}
+
+var batchLogsCmd = &cobra.Command{
+	Use:   "logs <batch-id> <ticket-id>",
+	Short: "Show logs for a ticket in a batch",
+	Args:  cobra.ExactArgs(2),
+	RunE:  runBatchLogs,
+}
+
+func init() {
+	rootCmd.AddCommand(batchCmd)
+	batchCmd.AddCommand(batchStatusCmd)
+	batchCmd.AddCommand(batchLogsCmd)
+
+	batchCmd.Flags().StringVarP(&batchFileFlag, "file", "F", "", "CSV or text file with ticket IDs")
+	batchCmd.Flags().IntVarP(&batchConcurrencyFlag, "concurrency", "n", 2, "Number of parallel workers")
+	batchCmd.Flags().StringVarP(&batchRepoFlag, "repo", "r", "", "Repository to work in")
+	batchCmd.Flags().Float64Var(&batchBudgetFlag, "budget", 0, "Max budget per ticket in USD (e.g., 5.00)")
+	batchCmd.Flags().StringVar(&batchPromptFlag, "prompt", "", "Custom prompt template (use {TICKET_ID} and {BRANCH} placeholders)")
+	batchCmd.Flags().StringVarP(&batchTypeFlag, "type", "t", "feature", "Branch type (feature, bug, spike, chore, hotfix, docs)")
+	batchCmd.Flags().StringVarP(&batchFromFlag, "from", "f", "", "Base branch to create from (default: origin's default branch)")
+	batchCmd.Flags().BoolVar(&batchDryRunFlag, "dry-run", false, "Preview what would be created without running")
+	batchCmd.Flags().BoolVar(&batchProjectFlag, "project", false, "Create a clade project per ticket (multi-repo workspace)")
+}
+
+func runBatch(cmd *cobra.Command, args []string) error {
+	// Collect ticket inputs from args and/or file
+	var inputs []batch.TicketInput
+
+	// From CLI args
+	for _, arg := range args {
+		inputs = append(inputs, batch.TicketInput{ID: arg})
+	}
+
+	// From file
+	if batchFileFlag != "" {
+		fileTickets, err := batch.ParseTicketsFromFile(batchFileFlag)
+		if err != nil {
+			return fmt.Errorf("failed to read tickets file: %w", err)
+		}
+		inputs = append(inputs, fileTickets...)
+	}
+
+	if len(inputs) == 0 {
+		return fmt.Errorf("no ticket IDs provided. Pass them as arguments or use --file")
+	}
+
+	// Deduplicate by ticket ID
+	inputs = dedupInputs(inputs)
+
+	// Resolve default repo
+	cfg, err := config.Load()
+	if err != nil {
+		return fmt.Errorf("failed to load config: %w", err)
+	}
+
+	defaultRepoPath, err := resolveRepo(cfg, batchRepoFlag)
+	if err != nil {
+		return err
+	}
+	defaultRepoName := git.GetRepoName(defaultRepoPath)
+
+	// Validate per-ticket repos if specified
+	for i, input := range inputs {
+		for j, repo := range input.Repos {
+			resolved, err := resolveRepo(cfg, repo)
+			if err != nil {
+				return fmt.Errorf("ticket %s: invalid repo '%s': %w", input.ID, repo, err)
+			}
+			inputs[i].Repos[j] = resolved
+		}
+	}
+
+	// Resolve label config
+	labelCfg, ok := cfg.GetLabelConfig(batchTypeFlag)
+	if !ok {
+		return fmt.Errorf("unknown type '%s'. %s", batchTypeFlag, availableTypesHelp(cfg))
+	}
+
+	// Dry run
+	if batchDryRunFlag {
+		return printBatchDryRun(inputs, defaultRepoName, defaultRepoPath, labelCfg.BranchPrefix, cfg)
+	}
+
+	// Create batch
+	b := batch.NewBatch(inputs, defaultRepoName, batchConcurrencyFlag, batchBudgetFlag, batchPromptFlag)
+
+	var createWorktreeFn func(ticket *batch.TicketResult) (*batch.WorktreeResult, error)
+
+	if batchProjectFlag {
+		// Project mode: create a clade project per ticket
+		createWorktreeFn = func(ticket *batch.TicketResult) (*batch.WorktreeResult, error) {
+			return createBatchProject(ticket, b, cfg, defaultRepoPath, labelCfg.BranchPrefix)
+		}
+	} else {
+		// Worktree mode: create individual worktrees per repo
+		createWorktreeFn = func(ticket *batch.TicketResult) (*batch.WorktreeResult, error) {
+			return createBatchWorktrees(ticket, b, cfg, defaultRepoPath, labelCfg.BranchPrefix)
+		}
+	}
+
+	return b.Run(defaultRepoPath, createWorktreeFn)
+}
+
+// createBatchWorktrees creates individual worktrees per repo for a ticket (original behavior)
+func createBatchWorktrees(ticket *batch.TicketResult, b *batch.BatchState, cfg *config.Config, defaultRepoPath, branchPrefix string) (*batch.WorktreeResult, error) {
+	ticketID := ticket.ID
+
+	// Determine repos for this ticket
+	repos := ticket.Repos
+	if len(repos) == 0 {
+		repos = []string{defaultRepoPath}
+	}
+
+	// Build branch name
+	var branch string
+	if branchPrefix != "" {
+		branch = branchPrefix + "/" + ticketID
+	} else {
+		branch = ticketID
+	}
+
+	result := &batch.WorktreeResult{Branch: branch}
+
+	// Create a worktree in each repo (serialized per source repo to avoid git lock conflicts)
+	for i, repoPath := range repos {
+		repoName := git.GetRepoName(repoPath)
+
+		// Lock per source repo to prevent concurrent git operations
+		mu := b.RepoMutex(repoPath)
+		mu.Lock()
+
+		// Check if worktree already exists
+		state, err := config.LoadState(cfg)
+		if err != nil {
+			mu.Unlock()
+			return nil, err
+		}
+
+		var wtPath string
+		if existing := state.GetWorktree(repoName, ticketID); existing != nil {
+			mu.Unlock()
+			ui.Info("[%s] Worktree for %s already exists, reusing", ticketID, repoName)
+			wtPath = config.GetWorktreePath(cfg, repoName, existing)
+		} else {
+			// Create worktree programmatically (no agent, no editor)
+			err = CreateWorktree(ticketID, WorktreeConfig{
+				Label:        batchTypeFlag,
+				BranchPrefix: branchPrefix,
+			}, WorktreeOptions{
+				RepoFlag:     repoPath,
+				FromFlag:     batchFromFlag,
+				NoAgentFlag:  true,
+				NoEditorFlag: true,
+			})
+			mu.Unlock()
+			if err != nil {
+				return nil, fmt.Errorf("repo %s: %w", repoName, err)
+			}
+			wtPath = config.WorktreePath(cfg, repoName, ticketID)
+		}
+
+		if i == 0 {
+			result.PrimaryPath = wtPath
+		} else {
+			result.AddDirs = append(result.AddDirs, wtPath)
+		}
+	}
+
+	return result, nil
+}
+
+// createBatchProject creates a clade project per ticket, grouping all repos under one directory
+func createBatchProject(ticket *batch.TicketResult, b *batch.BatchState, cfg *config.Config, defaultRepoPath, branchPrefix string) (*batch.WorktreeResult, error) {
+	ticketID := ticket.ID
+
+	// Determine repos for this ticket
+	repos := ticket.Repos
+	if len(repos) == 0 {
+		repos = []string{defaultRepoPath}
+	}
+
+	// Build branch name
+	var branch string
+	if branchPrefix != "" {
+		branch = branchPrefix + "/" + ticketID
+	} else {
+		branch = ticketID
+	}
+
+	// Check if project already exists
+	state, err := config.LoadState(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	if existing, ok := state.Projects[ticketID]; ok {
+		ui.Info("[%s] Project already exists, reusing", ticketID)
+		result := &batch.WorktreeResult{Branch: existing.Branch}
+		if len(existing.Repos) > 0 {
+			result.PrimaryPath = filepath.Join(existing.Path, existing.Repos[0].Name)
+			for i := 1; i < len(existing.Repos); i++ {
+				result.AddDirs = append(result.AddDirs, filepath.Join(existing.Path, existing.Repos[i].Name))
+			}
+		}
+		return result, nil
+	}
+
+	// Create project directory
+	projectPath := filepath.Join(cfg.ProjectsDir(), ticketID)
+	if err := os.MkdirAll(projectPath, 0755); err != nil {
+		return nil, fmt.Errorf("failed to create project directory: %w", err)
+	}
+
+	// Preflight check all repos
+	branchResults := git.PreflightCheck(repos, branch)
+
+	// Create worktrees for each repo
+	var createdRepos []config.ProjectRepo
+	result := &batch.WorktreeResult{Branch: branch}
+
+	for i, repoPath := range repos {
+		repoName := git.GetRepoName(repoPath)
+		folderName := filepath.Base(repoPath)
+		worktreePath := filepath.Join(projectPath, folderName)
+		info := branchResults[repoPath]
+
+		// Lock per source repo to prevent concurrent git operations
+		mu := b.RepoMutex(repoPath)
+		mu.Lock()
+
+		ui.Info("[%s] Creating %s...", ticketID, folderName)
+
+		var wtErr error
+		switch info.Status {
+		case git.BranchNotFound:
+			_, wtErr = git.CreateWorktreeNew(repoPath, worktreePath, branch, "")
+		case git.BranchLocalOnly, git.BranchBoth:
+			wtErr = git.CreateWorktreeFromBranch(repoPath, worktreePath, branch)
+		case git.BranchRemoteOnly:
+			wtErr = git.CreateWorktreeTrackRemote(repoPath, worktreePath, branch)
+		}
+
+		mu.Unlock()
+
+		if wtErr != nil {
+			// Clean up partial project on failure
+			for _, r := range createdRepos {
+				os.RemoveAll(filepath.Join(projectPath, r.Name))
+			}
+			os.Remove(projectPath)
+			return nil, fmt.Errorf("repo %s: %w", repoName, wtErr)
+		}
+
+		// Copy gitignored files (.env, .npmrc, etc.)
+		if err := copyGitignoredFilesForProject(cfg, repoPath, worktreePath); err != nil {
+			ui.Warn("[%s] Failed to copy some files for %s: %v", ticketID, folderName, err)
+		}
+
+		createdRepos = append(createdRepos, config.ProjectRepo{
+			Name:   folderName,
+			Source: repoPath,
+		})
+
+		if i == 0 {
+			result.PrimaryPath = worktreePath
+		} else {
+			result.AddDirs = append(result.AddDirs, worktreePath)
+		}
+	}
+
+	// Write .clade-project.json
+	projectMeta := map[string]interface{}{
+		"type":    "project",
+		"name":    ticketID,
+		"branch":  branch,
+		"repos":   createdRepos,
+		"created": time.Now().Format(time.RFC3339),
+	}
+	metaPath := filepath.Join(projectPath, ".clade-project.json")
+	if err := writeProjectJSON(metaPath, projectMeta); err != nil {
+		ui.Warn("[%s] Failed to write .clade-project.json: %v", ticketID, err)
+	}
+
+	// Update state
+	project := &config.Project{
+		Name:     ticketID,
+		Path:     projectPath,
+		Branch:   branch,
+		Repos:    createdRepos,
+		Created:  time.Now(),
+		LastUsed: time.Now(),
+	}
+	state.Projects[ticketID] = project
+	if err := state.Save(cfg); err != nil {
+		ui.Warn("[%s] Failed to save state: %v", ticketID, err)
+	}
+
+	return result, nil
+}
+
+func runBatchStatus(cmd *cobra.Command, args []string) error {
+	if len(args) == 1 {
+		// Show specific batch
+		b, err := batch.LoadBatch(args[0])
+		if err != nil {
+			return fmt.Errorf("failed to load batch '%s': %w", args[0], err)
+		}
+		b.PrintStatus()
+		return nil
+	}
+
+	// List all batches
+	ids, err := batch.ListBatches()
+	if err != nil {
+		return fmt.Errorf("failed to list batches: %w", err)
+	}
+
+	if len(ids) == 0 {
+		ui.Info("No batch runs found")
+		return nil
+	}
+
+	ui.Header("Batch runs")
+	for _, id := range ids {
+		b, err := batch.LoadBatch(id)
+		if err != nil {
+			ui.Warn("Failed to load batch %s: %v", id, err)
+			continue
+		}
+
+		var done, failed, blocked, total int
+		total = len(b.Tickets)
+		for _, t := range b.Tickets {
+			switch t.Status {
+			case batch.StatusDone:
+				done++
+			case batch.StatusFailed:
+				failed++
+			case batch.StatusBlocked:
+				blocked++
+			}
+		}
+
+		status := ui.Green("complete")
+		if failed > 0 || blocked > 0 {
+			parts := fmt.Sprintf("%d/%d done", done, total)
+			if blocked > 0 {
+				parts += fmt.Sprintf(", %d blocked", blocked)
+			}
+			if failed > 0 {
+				parts += fmt.Sprintf(", %d failed", failed)
+			}
+			status = ui.Yellow(parts)
+		} else if done < total {
+			status = ui.Cyan(fmt.Sprintf("%d/%d done", done, total))
+		}
+
+		fmt.Printf("  %s  %s  %s  %s\n",
+			ui.Cyan(id),
+			ui.Dim("("+b.Repo+")"),
+			status,
+			ui.Dim(fmt.Sprintf("%d tickets", total)),
+		)
+	}
+
+	return nil
+}
+
+func runBatchLogs(cmd *cobra.Command, args []string) error {
+	batchID := args[0]
+	ticketID := args[1]
+
+	b, err := batch.LoadBatch(batchID)
+	if err != nil {
+		return fmt.Errorf("failed to load batch '%s': %w", batchID, err)
+	}
+
+	// Find the ticket
+	var logFile string
+	for _, t := range b.Tickets {
+		if t.ID == ticketID {
+			logFile = t.LogFile
+			break
+		}
+	}
+
+	if logFile == "" {
+		logFile = filepath.Join(batch.BatchDir(), batchID, "logs", ticketID+".log")
+	}
+
+	data, err := os.ReadFile(logFile)
+	if err != nil {
+		return fmt.Errorf("no logs found for %s in batch %s", ticketID, batchID)
+	}
+
+	fmt.Print(string(data))
+	return nil
+}
+
+func printBatchDryRun(inputs []batch.TicketInput, defaultRepoName, defaultRepoPath, branchPrefix string, cfg *config.Config) error {
+	fmt.Println()
+	fmt.Println(ui.Bold("Dry run - no changes will be made"))
+	fmt.Println()
+
+	ui.KeyValue("Default repo", fmt.Sprintf("%s (%s)", defaultRepoName, defaultRepoPath))
+	ui.KeyValue("Tickets", fmt.Sprintf("%d", len(inputs)))
+	ui.KeyValue("Concurrency", fmt.Sprintf("%d", batchConcurrencyFlag))
+	if batchProjectFlag {
+		ui.KeyValue("Mode", "project (multi-repo workspace per ticket)")
+	}
+	if batchBudgetFlag > 0 {
+		ui.KeyValue("Budget per ticket", fmt.Sprintf("$%.2f", batchBudgetFlag))
+	}
+
+	fmt.Println()
+	fmt.Println(ui.Dim("Would create:"))
+	for _, input := range inputs {
+		var branch string
+		if branchPrefix != "" {
+			branch = branchPrefix + "/" + input.ID
+		} else {
+			branch = input.ID
+		}
+		if len(input.Repos) > 1 {
+			var repoNames []string
+			for _, r := range input.Repos {
+				repoNames = append(repoNames, git.GetRepoName(r))
+			}
+			fmt.Printf("  %s → branch %s %s\n", ui.Cyan(input.ID), ui.Dim(branch), ui.Dim(fmt.Sprintf("(%s)", strings.Join(repoNames, " + "))))
+		} else if len(input.Repos) == 1 {
+			fmt.Printf("  %s → branch %s %s\n", ui.Cyan(input.ID), ui.Dim(branch), ui.Dim(fmt.Sprintf("(%s)", git.GetRepoName(input.Repos[0]))))
+		} else {
+			fmt.Printf("  %s → branch %s\n", ui.Cyan(input.ID), ui.Dim(branch))
+		}
+	}
+
+	fmt.Println()
+	fmt.Println(ui.Dim("Each ticket will run:"))
+	fmt.Printf("  claude -p <prompt> --permission-mode bypassPermissions\n")
+	if batchBudgetFlag > 0 {
+		fmt.Printf("  --max-budget-usd %.2f\n", batchBudgetFlag)
+	}
+
+	fmt.Println()
+	fmt.Println(ui.Dim("Remove --dry-run to execute"))
+	return nil
+}
+
+func dedupInputs(inputs []batch.TicketInput) []batch.TicketInput {
+	seen := make(map[string]bool)
+	var result []batch.TicketInput
+	for _, input := range inputs {
+		key := strings.TrimSpace(input.ID)
+		if key != "" && !seen[key] {
+			seen[key] = true
+			input.ID = key
+			result = append(result, input)
+		}
+	}
+	return result
+}


### PR DESCRIPTION
Run multiple Jira tickets concurrently with autonomous Claude agents. Each ticket gets its own worktree or project workspace. Supports CSV input with per-ticket repo assignment, custom prompts, concurrency control, and per-repo mutex to prevent git lock conflicts.

Includes --project flag for multi-repo project workspaces and comprehensive test suite.

## Summary

Brief description of the changes.

## Changes

- Change 1
- Change 2

## Testing

How was this tested?

- [ ] `go test ./...` passes
- [ ] `go build ./...` succeeds
- [ ] Manual testing done

## Checklist

- [ ] Code follows project style
- [ ] Documentation updated (if needed)
- [ ] CHANGELOG.md updated (for user-facing changes)
