### PR TITLE
feat(batch): add --jira-label and --jira-project for label-based ticket fetching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- **Label-based ticket fetching for `clade batch`:**
+  - `--jira-label <labels>` — comma-separated Jira labels; resolves matching ticket IDs via the Atlassian Jira MCP (no Go-side Jira client, no credentials handled by clade). **Multiple labels use AND semantics** — a ticket must carry all of them to match, enabling convention-based per-repo routing (e.g. `--jira-label for-agents,leap_one_server -r leap_one_server`).
+  - `--jira-project <keys>` — comma-separated Jira project keys scoping the label search (OR-scoped). Requires `--jira-label`.
+  - Composes with positional args and `--file`: inputs from all sources are merged and deduplicated.
+  - `--dry-run` resolves and prints matched tickets without dispatching work.
+- **Docs:** full `clade batch` section in `USER_GUIDE.md` (commands, flags, CSV format, label workflow, per-repo routing guidance); batch entries added to `README.md` and `CLAUDE.md` quick references.
+
 ## [0.7.0] - 2026-03-20
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,6 +45,13 @@ clade repo remove my-repo         # Unregister
 clade init                        # Setup .claude/ with hooks
 clade doctor                      # Diagnose configuration issues
 
+# Batch mode (parallel ticket processing)
+clade batch PROJ-1 PROJ-2                       # From args
+clade batch --file tickets.csv                  # From CSV
+clade batch --jira-label bug                    # From Jira label (via MCP)
+clade batch --jira-label bug --jira-project PROJ --concurrency 3
+clade batch status                              # List batches
+
 # Useful flags
 clade foo -p                      # Force repo picker
 clade foo -r my-api               # Use specific repo

--- a/README.md
+++ b/README.md
@@ -97,7 +97,16 @@ clade repo list                # Show registered repos
 clade init                     # Setup hooks in current repo
 clade doctor                   # Diagnose configuration issues
 clade status                   # Show context for current dir
+
+# Batch mode (parallel ticket processing)
+clade batch PROJ-1 PROJ-2              # From args
+clade batch --file tickets.csv         # From CSV/text
+clade batch --jira-label triage-bug    # Fetched from Jira by label
+clade batch --jira-label bug --jira-project PROJ --concurrency 3
+clade batch status                     # List all batches
 ```
+
+See [USER_GUIDE.md](USER_GUIDE.md#clade-batch-tickets) for full batch-mode docs.
 
 ### Key Flags
 

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -691,6 +691,127 @@ Cleaned up worktree 'try-redis'
 
 ---
 
+### `clade batch <tickets...>`
+
+**Purpose:** Process multiple Jira tickets in parallel, each in its own worktree with an autonomous Claude agent.
+
+```bash
+clade batch PROJ-123 PROJ-456                   # Direct ticket IDs
+clade batch --file tickets.csv                  # From CSV
+clade batch --file tickets.txt                  # From text (one ID per line)
+clade batch --jira-label triage-bug             # Fetched from Jira by label
+clade batch --jira-label bug --jira-project SALESPRO,LEAP
+```
+
+**How it works:**
+1. Clade gathers ticket IDs from all provided sources (args, `--file`, `--jira-label`), merges, and deduplicates.
+2. For each ticket, a worktree is created on a per-ticket branch.
+3. Each worktree runs `claude -p <prompt> --permission-mode bypassPermissions` autonomously. The default prompt instructs Claude to fetch the ticket (via Jira MCP), implement the change, run tests, push, and open a PR.
+4. Workers run in parallel (configurable). Logs and state land in `~/.config/clade/batches/{id}/`.
+
+**Input sources:**
+
+| Source | Flag | Notes |
+|---|---|---|
+| Positional args | `clade batch A-1 A-2` | Space-separated ticket IDs. |
+| CSV / text file | `--file / -F` | CSV supports `ticket`, `id`, `key`, `ticket_id` headers plus optional `repos` column (multi-repo per ticket). One-per-line text works too. |
+| Jira label query | `--jira-label` | Comma-separated labels. Delegated to the Atlassian Jira MCP — clade does not talk to Jira directly. |
+| Jira project scope | `--jira-project` | Comma-separated project keys. Optional; requires `--jira-label`. |
+
+All sources are merged and deduplicated — feel free to combine positional args, a CSV, and a label query in one invocation.
+
+**Flags:**
+
+| Flag | Default | Purpose |
+|---|---|---|
+| `-F, --file` | — | CSV or text file of ticket IDs (optionally with per-ticket repos). |
+| `-n, --concurrency` | `2` | Number of parallel workers. |
+| `-r, --repo` | first registered | Default repo to work in (registered repo name or path). |
+| `-t, --type` | `feature` | Branch type (`feature`, `bug`, `spike`, `chore`, `hotfix`, `docs`, or config-defined). |
+| `-f, --from` | origin default | Base branch to create each ticket's branch from. |
+| `--budget` | — | Max USD per ticket passed to `claude --max-budget-usd`. |
+| `--prompt` | — | Override the default agent prompt. Placeholders: `{TICKET_ID}`, `{BRANCH}`. |
+| `--project` | off | Create a clade multi-repo workspace per ticket instead of a single worktree. |
+| `--jira-label` | — | Comma-separated Jira labels to fetch tickets for. |
+| `--jira-project` | — | Comma-separated Jira project keys scoping the label search. Requires `--jira-label`. |
+| `--dry-run` | off | Print what would be created (including resolved label IDs); run nothing. |
+
+**Subcommands:**
+
+```bash
+clade batch status               # List all batches
+clade batch status <batch-id>    # Detailed status for one batch
+clade batch logs <batch-id> <ticket-id>   # Full log for a ticket's agent run
+```
+
+**CSV format:**
+
+```csv
+ticket,repos
+PROJ-100,my-api
+PROJ-200,"my-api,my-frontend"
+PROJ-300,
+```
+
+Headers are optional (if absent, one ticket ID per line). The `repos` column is optional — when present, a ticket can span multiple repos, each getting a worktree on the shared branch.
+
+**Example — label fetch with dry-run:**
+
+```bash
+$ clade batch --jira-label triage-bug --jira-project SALESPRO --dry-run
+
+Fetching tickets from Jira for labels: triage-bug
+
+Dry run - no changes will be made
+
+Default repo: leap-360 (~/repos/leap-360)
+Tickets: 4
+Concurrency: 2
+Jira labels: triage-bug
+Jira projects: SALESPRO
+Resolved from labels: 4
+
+Would create:
+  SALESPRO-6493 → branch fix/SALESPRO-6493
+  SALESPRO-6501 → branch fix/SALESPRO-6501
+  SALESPRO-6510 → branch fix/SALESPRO-6510
+  SALESPRO-6514 → branch fix/SALESPRO-6514
+```
+
+**Prerequisites for label fetching:**
+- The Atlassian Jira MCP must be configured and authenticated in the Claude CLI used by the current shell.
+- Clade does not store or handle Jira credentials directly — the MCP owns that.
+
+**Label semantics:**
+- Multiple labels are combined with **AND** — a ticket must carry every label to match.
+- Multiple `--jira-project` values are OR-scoped (tickets in any of the listed projects).
+- To OR labels (match any), run clade once per label.
+
+**Routing tickets to repos via labels:**
+
+Clade does not inspect ticket content to choose a repo. Label fetching
+assigns every resolved ticket to the default repo (`-r`), same as
+positional args. If you have multiple repos and want each ticket to land
+in the right one, a convention-based approach works well:
+
+1. In Jira, tag every agent-ready ticket with two labels — a "pick me" label
+   like `for-agents` and a repo-name label matching the registered clade
+   repo (e.g. `leap_one_server`).
+2. Run one clade batch per repo:
+   ```bash
+   clade batch --jira-label for-agents,leap_one_server -r leap_one_server
+   clade batch --jira-label for-agents,salespro       -r salespro
+   ```
+
+Because label semantics are AND, each command returns only the tickets
+meant for that repo.
+
+For richer per-ticket repo metadata (pulling repo info from a Jira custom
+field, or carrying multi-repo assignments), use the CSV path with a
+`repos` column. See the "CSV format" section above.
+
+---
+
 ### `clade migrate`
 
 **Purpose:** Migrate existing experiments from v1 to v2 repo-centric structure.
@@ -994,6 +1115,37 @@ $ clade cleanup PROJ-1234
 
 ---
 
+### Scenario 5: Batch-process tickets by Jira label (with per-repo routing)
+
+You have multiple repos and want to dispatch the agent-ready tickets for each repo. Tag every agent-ready ticket in Jira with two labels:
+
+- `for-agents` — a shared "pick me up" label.
+- `<repo-name>` — matches the registered clade repo name (e.g. `leap_one_server`, `salespro`).
+
+Then run one batch per repo. Because labels are AND'd, each command pulls only the tickets meant for that repo.
+
+```bash
+# Preview what you'd get for the leap_one_server repo
+$ clade batch --jira-label for-agents,leap_one_server -r leap_one_server --dry-run
+
+# Launch it for real: 3 workers, $5 cap per ticket
+$ clade batch --jira-label for-agents,leap_one_server -r leap_one_server \
+    --concurrency 3 --type bug --budget 5.00
+
+# Then the salespro repo
+$ clade batch --jira-label for-agents,salespro -r salespro --concurrency 3
+
+# Check progress across all running batches
+$ clade batch status
+
+# Drill into one ticket's agent log
+$ clade batch logs 2026-04-20-0930 SALESPRO-6493
+```
+
+Each ticket gets its own worktree, its own autonomous Claude session, and a PR (or a "needs more detail" comment back on the ticket, if the description was too vague). Clade does not mutate Jira directly; the agents do that via the Jira MCP.
+
+---
+
 ## Quick Reference
 
 ```bash
@@ -1025,6 +1177,15 @@ clade scratch doc-review          # No-git scratch folder
 clade status                      # Current context
 clade doctor                      # Diagnose configuration issues
 clade migrate                     # Migrate v1 -> v2 structure
+
+# Batch mode (parallel ticket processing)
+clade batch PROJ-1 PROJ-2                       # From args
+clade batch --file tickets.csv                  # From CSV/text
+clade batch --jira-label bug                    # Fetched from Jira by label
+clade batch --jira-label bug --jira-project PROJ,OTHER --concurrency 3
+clade batch status                              # List all batches
+clade batch status <batch-id>                   # Detailed batch status
+clade batch logs <batch-id> <ticket-id>         # Ticket log
 
 # Useful flags
 clade foo -p                      # Force repo picker

--- a/internal/batch/jira_labels.go
+++ b/internal/batch/jira_labels.go
@@ -1,0 +1,268 @@
+package batch
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+// LabelQueryRunner executes a Claude one-shot query and returns stdout.
+// Abstracted so tests can inject canned responses without shelling out.
+type LabelQueryRunner func(prompt string) ([]byte, error)
+
+// labelQueryResponse is the JSON contract clade asks Claude to emit.
+//
+// Claude must respond with a single line of the form:
+//
+//	{"tickets":["PROJ-1","PROJ-2"],"error":null}
+//
+// On failure (MCP unavailable, query error) Claude emits:
+//
+//	{"tickets":[],"error":"<brief reason>"}
+type labelQueryResponse struct {
+	Tickets []string `json:"tickets"`
+	Error   *string  `json:"error"`
+}
+
+// FetchTicketsByLabel resolves Jira ticket IDs matching the given labels
+// (and optional project keys) by delegating the query to Claude via the
+// Jira MCP. Returns TicketInput values ready to feed into the batch
+// pipeline.
+func FetchTicketsByLabel(labels, projects []string) ([]TicketInput, error) {
+	return fetchTicketsByLabel(labels, projects, execClaudeLabelQuery)
+}
+
+func fetchTicketsByLabel(labels, projects []string, runner LabelQueryRunner) ([]TicketInput, error) {
+	labels = cleanList(labels)
+	projects = cleanList(projects)
+	if len(labels) == 0 {
+		return nil, fmt.Errorf("at least one label is required")
+	}
+
+	jql := buildJQL(labels, projects)
+	prompt := buildLabelQueryPrompt(jql)
+
+	stdout, err := runner(prompt)
+	if err != nil {
+		return nil, fmt.Errorf("claude query failed: %w", err)
+	}
+
+	return parseTicketsOutput(stdout, jql)
+}
+
+// cleanList trims whitespace and drops empty entries.
+func cleanList(values []string) []string {
+	out := make([]string, 0, len(values))
+	for _, v := range values {
+		v = strings.TrimSpace(v)
+		if v != "" {
+			out = append(out, v)
+		}
+	}
+	return out
+}
+
+// buildJQL composes a JQL query from labels and optional projects.
+//
+// Multiple labels are combined with AND — a ticket must carry all of them
+// to match. This lets callers narrow results with e.g. a routing label
+// (`--jira-label for-agents,leap_one_server` returns tickets that have
+// BOTH labels, not either).
+//
+// Projects are combined with OR ("in any of these projects"), which is
+// the common scoping case. Values are quoted to tolerate spaces,
+// hyphens, and other benign chars.
+func buildJQL(labels, projects []string) string {
+	var parts []string
+	if len(projects) > 0 {
+		parts = append(parts, fmt.Sprintf("project in (%s)", quoteJoin(projects)))
+	}
+	for _, label := range labels {
+		parts = append(parts, fmt.Sprintf("labels = %s", strconv.Quote(label)))
+	}
+	return strings.Join(parts, " AND ")
+}
+
+func quoteJoin(values []string) string {
+	quoted := make([]string, len(values))
+	for i, v := range values {
+		quoted[i] = strconv.Quote(v)
+	}
+	return strings.Join(quoted, ",")
+}
+
+// buildLabelQueryPrompt returns the prompt text clade sends to Claude.
+// The contract is intentionally rigid: Claude must emit exactly one JSON
+// line that clade can parse — nothing else, no prose, no code fences.
+func buildLabelQueryPrompt(jql string) string {
+	return fmt.Sprintf(`You have access to the Atlassian Jira MCP tools.
+
+Run searchJiraIssuesUsingJql with this JQL:
+  %s
+
+OUTPUT RULES — follow them exactly:
+- Output a single line of JSON, and NOTHING else.
+- No prose. No explanation. No markdown code fences. No leading or trailing lines.
+- On success, the line must match this shape:
+    {"tickets":["PROJ-123","PROJ-124"],"error":null}
+- On zero matches (query succeeded, no results):
+    {"tickets":[],"error":null}
+- On any failure (MCP unavailable, auth error, invalid JQL):
+    {"tickets":[],"error":"<brief reason>"}
+- Only include ticket keys (e.g. PROJ-123), not URLs, summaries, or other fields.`, jql)
+}
+
+// parseTicketsOutput scans Claude's stdout for a line that matches the
+// labelQueryResponse contract. It tolerates prose before/after the JSON
+// line; if line-by-line scanning fails, it falls back to extracting the
+// outermost balanced JSON object from the whole buffer (handles the case
+// where Claude pretty-prints the JSON over multiple lines).
+func parseTicketsOutput(stdout []byte, jql string) ([]TicketInput, error) {
+	resp, ok := findResponseLine(stdout)
+	if !ok {
+		resp, ok = findResponseInBuffer(stdout)
+	}
+	if !ok {
+		return nil, fmt.Errorf(
+			"could not parse claude response (expected JSON with 'tickets' field)\nJQL: %s\nstdout: %s",
+			jql,
+			truncateForError(string(stdout), 500),
+		)
+	}
+
+	if resp.Error != nil && *resp.Error != "" {
+		return nil, fmt.Errorf("jira query failed: %s\nJQL: %s", *resp.Error, jql)
+	}
+
+	if len(resp.Tickets) == 0 {
+		return nil, fmt.Errorf("no tickets matched JQL: %s", jql)
+	}
+
+	inputs := make([]TicketInput, 0, len(resp.Tickets))
+	for _, id := range resp.Tickets {
+		id = strings.TrimSpace(id)
+		if id != "" {
+			inputs = append(inputs, TicketInput{ID: id})
+		}
+	}
+
+	if len(inputs) == 0 {
+		return nil, fmt.Errorf("no valid ticket IDs in response\nJQL: %s", jql)
+	}
+
+	return inputs, nil
+}
+
+// findResponseLine walks stdout line-by-line and returns the first line
+// that parses as a labelQueryResponse carrying one of our fields.
+func findResponseLine(stdout []byte) (*labelQueryResponse, bool) {
+	scanner := bufio.NewScanner(bytes.NewReader(stdout))
+	scanner.Buffer(make([]byte, 0, 64*1024), 10*1024*1024)
+
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if !strings.HasPrefix(line, "{") || !strings.HasSuffix(line, "}") {
+			continue
+		}
+		if resp, ok := tryUnmarshalResponse([]byte(line)); ok {
+			return resp, true
+		}
+	}
+	return nil, false
+}
+
+// findResponseInBuffer is a fallback for pretty-printed JSON that spans
+// multiple lines. It extracts the first balanced {...} object from the
+// buffer and tries to unmarshal it.
+func findResponseInBuffer(stdout []byte) (*labelQueryResponse, bool) {
+	start := bytes.IndexByte(stdout, '{')
+	for start != -1 {
+		end := matchBalancedBrace(stdout, start)
+		if end == -1 {
+			return nil, false
+		}
+		if resp, ok := tryUnmarshalResponse(stdout[start : end+1]); ok {
+			return resp, true
+		}
+		// Not our shape — skip past this object and keep looking.
+		next := bytes.IndexByte(stdout[end+1:], '{')
+		if next == -1 {
+			return nil, false
+		}
+		start = end + 1 + next
+	}
+	return nil, false
+}
+
+// matchBalancedBrace returns the index of the '}' that closes the '{' at
+// openIdx, or -1 if unbalanced. String literals are respected so braces
+// inside JSON strings don't confuse the count.
+func matchBalancedBrace(buf []byte, openIdx int) int {
+	depth := 0
+	inString := false
+	escaped := false
+	for i := openIdx; i < len(buf); i++ {
+		c := buf[i]
+		if escaped {
+			escaped = false
+			continue
+		}
+		if inString {
+			switch c {
+			case '\\':
+				escaped = true
+			case '"':
+				inString = false
+			}
+			continue
+		}
+		switch c {
+		case '"':
+			inString = true
+		case '{':
+			depth++
+		case '}':
+			depth--
+			if depth == 0 {
+				return i
+			}
+		}
+	}
+	return -1
+}
+
+// tryUnmarshalResponse attempts to parse raw as a labelQueryResponse and
+// requires at least one of our fields to be present (so we don't accept
+// unrelated JSON that happens to live in stdout).
+func tryUnmarshalResponse(raw []byte) (*labelQueryResponse, bool) {
+	var candidate labelQueryResponse
+	if err := json.Unmarshal(raw, &candidate); err != nil {
+		return nil, false
+	}
+	if candidate.Tickets == nil && candidate.Error == nil {
+		return nil, false
+	}
+	return &candidate, true
+}
+
+func truncateForError(s string, max int) string {
+	if len(s) <= max {
+		return s
+	}
+	return s[:max] + "..."
+}
+
+func execClaudeLabelQuery(prompt string) ([]byte, error) {
+	cmd := exec.Command("claude", "-p", prompt, "--permission-mode", "bypassPermissions")
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return stdout.Bytes(), fmt.Errorf("%w: %s", err, strings.TrimSpace(stderr.String()))
+	}
+	return stdout.Bytes(), nil
+}

--- a/internal/batch/jira_labels_test.go
+++ b/internal/batch/jira_labels_test.go
@@ -1,0 +1,269 @@
+package batch
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildJQL(t *testing.T) {
+	tests := []struct {
+		name     string
+		labels   []string
+		projects []string
+		want     string
+	}{
+		{
+			name:   "single label, no project",
+			labels: []string{"bug"},
+			want:   `labels = "bug"`,
+		},
+		{
+			name:     "single label, single project",
+			labels:   []string{"bug"},
+			projects: []string{"PROJ"},
+			want:     `project in ("PROJ") AND labels = "bug"`,
+		},
+		{
+			name:     "multiple labels use AND semantics",
+			labels:   []string{"for-agents", "leap_one_server"},
+			projects: []string{"LEAP"},
+			want:     `project in ("LEAP") AND labels = "for-agents" AND labels = "leap_one_server"`,
+		},
+		{
+			name:     "multiple labels and multiple projects",
+			labels:   []string{"bug", "urgent"},
+			projects: []string{"PROJ", "OTHER"},
+			want:     `project in ("PROJ","OTHER") AND labels = "bug" AND labels = "urgent"`,
+		},
+		{
+			name:   "label with space is quoted",
+			labels: []string{"needs design"},
+			want:   `labels = "needs design"`,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := buildJQL(tc.labels, tc.projects)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestCleanList(t *testing.T) {
+	got := cleanList([]string{" bug ", "", "urgent", "   "})
+	assert.Equal(t, []string{"bug", "urgent"}, got)
+}
+
+func TestBuildLabelQueryPrompt(t *testing.T) {
+	prompt := buildLabelQueryPrompt(`labels = "bug"`)
+	assert.Contains(t, prompt, "searchJiraIssuesUsingJql")
+	assert.Contains(t, prompt, `labels = "bug"`)
+	assert.Contains(t, prompt, `{"tickets":`)
+	assert.Contains(t, prompt, "OUTPUT RULES")
+}
+
+func TestParseTicketsOutput_CleanJSON(t *testing.T) {
+	out := []byte(`{"tickets":["PROJ-1","PROJ-2"],"error":null}`)
+	got, err := parseTicketsOutput(out, "test jql")
+	require.NoError(t, err)
+	assert.Equal(t, []TicketInput{{ID: "PROJ-1"}, {ID: "PROJ-2"}}, got)
+}
+
+func TestParseTicketsOutput_JSONWithProse(t *testing.T) {
+	out := []byte(`Sure! Here is the result:
+{"tickets":["PROJ-1"],"error":null}
+Let me know if you need more.`)
+	got, err := parseTicketsOutput(out, "test jql")
+	require.NoError(t, err)
+	assert.Equal(t, []TicketInput{{ID: "PROJ-1"}}, got)
+}
+
+func TestParseTicketsOutput_JSONInCodeFence(t *testing.T) {
+	out := []byte("```json\n" +
+		`{"tickets":["PROJ-1","PROJ-2"],"error":null}` + "\n" +
+		"```")
+	got, err := parseTicketsOutput(out, "test jql")
+	require.NoError(t, err)
+	assert.Equal(t, []TicketInput{{ID: "PROJ-1"}, {ID: "PROJ-2"}}, got)
+}
+
+func TestParseTicketsOutput_MultilineJSON(t *testing.T) {
+	// Claude pretty-prints over multiple lines — line-by-line scan fails,
+	// fallback extracts the balanced {...} object.
+	out := []byte(`Here you go:
+{
+  "tickets": ["PROJ-1", "PROJ-2"],
+  "error": null
+}`)
+	got, err := parseTicketsOutput(out, "test jql")
+	require.NoError(t, err)
+	assert.Equal(t, []TicketInput{{ID: "PROJ-1"}, {ID: "PROJ-2"}}, got)
+}
+
+func TestParseTicketsOutput_ErrorField(t *testing.T) {
+	out := []byte(`{"tickets":[],"error":"MCP not configured"}`)
+	_, err := parseTicketsOutput(out, `labels = "bug"`)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "jira query failed")
+	assert.Contains(t, err.Error(), "MCP not configured")
+	assert.Contains(t, err.Error(), `labels = "bug"`)
+}
+
+func TestParseTicketsOutput_ZeroMatches(t *testing.T) {
+	out := []byte(`{"tickets":[],"error":null}`)
+	_, err := parseTicketsOutput(out, `labels = "foo"`)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no tickets matched")
+	assert.Contains(t, err.Error(), `labels = "foo"`)
+}
+
+func TestParseTicketsOutput_NoJSON(t *testing.T) {
+	out := []byte(`I am sorry, I cannot help with that.`)
+	_, err := parseTicketsOutput(out, "test jql")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "could not parse")
+	assert.Contains(t, err.Error(), "I am sorry")
+}
+
+func TestParseTicketsOutput_IgnoresIrrelevantJSON(t *testing.T) {
+	// An unrelated JSON object appears first; our response comes later.
+	out := []byte(`{"status":"ok","count":3}
+{"tickets":["PROJ-1"],"error":null}`)
+	got, err := parseTicketsOutput(out, "test jql")
+	require.NoError(t, err)
+	assert.Equal(t, []TicketInput{{ID: "PROJ-1"}}, got)
+}
+
+func TestParseTicketsOutput_TrimsIDs(t *testing.T) {
+	out := []byte(`{"tickets":["  PROJ-1  ","PROJ-2"],"error":null}`)
+	got, err := parseTicketsOutput(out, "test jql")
+	require.NoError(t, err)
+	assert.Equal(t, []TicketInput{{ID: "PROJ-1"}, {ID: "PROJ-2"}}, got)
+}
+
+func TestParseTicketsOutput_AllEmptyIDs(t *testing.T) {
+	out := []byte(`{"tickets":["","   "],"error":null}`)
+	_, err := parseTicketsOutput(out, "test jql")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no valid ticket IDs")
+}
+
+func TestParseTicketsOutput_ErrorOnlyFieldWithoutTickets(t *testing.T) {
+	// Claude returns just the error field, no tickets key at all.
+	out := []byte(`{"error":"something broke"}`)
+	_, err := parseTicketsOutput(out, "test jql")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "something broke")
+}
+
+func TestParseTicketsOutput_LargeBuffer(t *testing.T) {
+	// Build a buffer well larger than bufio's default 64KB to verify the
+	// scanner buffer handles it.
+	var sb strings.Builder
+	for i := 0; i < 5000; i++ {
+		sb.WriteString("this is a filler line of prose from claude's explanation\n")
+	}
+	sb.WriteString(`{"tickets":["PROJ-1"],"error":null}` + "\n")
+	got, err := parseTicketsOutput([]byte(sb.String()), "test jql")
+	require.NoError(t, err)
+	assert.Equal(t, []TicketInput{{ID: "PROJ-1"}}, got)
+}
+
+func TestFetchTicketsByLabel_RunnerHappy(t *testing.T) {
+	runner := func(prompt string) ([]byte, error) {
+		assert.Contains(t, prompt, `labels = "bug"`)
+		return []byte(`{"tickets":["PROJ-1","PROJ-2"],"error":null}`), nil
+	}
+	got, err := fetchTicketsByLabel([]string{"bug"}, nil, runner)
+	require.NoError(t, err)
+	assert.Equal(t, []TicketInput{{ID: "PROJ-1"}, {ID: "PROJ-2"}}, got)
+}
+
+func TestFetchTicketsByLabel_RunnerHappyWithProjects(t *testing.T) {
+	runner := func(prompt string) ([]byte, error) {
+		assert.Contains(t, prompt, `project in ("PROJ") AND labels = "bug"`)
+		return []byte(`{"tickets":["PROJ-1"],"error":null}`), nil
+	}
+	got, err := fetchTicketsByLabel([]string{"bug"}, []string{"PROJ"}, runner)
+	require.NoError(t, err)
+	assert.Equal(t, []TicketInput{{ID: "PROJ-1"}}, got)
+}
+
+func TestFetchTicketsByLabel_MultipleLabelsUseAND(t *testing.T) {
+	// Verifies the repo-routing-via-label workflow:
+	//   clade batch --jira-label for-agents,leap_one_server -r leap_one_server
+	// Must AND the labels so only tickets with BOTH labels are returned.
+	runner := func(prompt string) ([]byte, error) {
+		assert.Contains(t, prompt, `labels = "for-agents" AND labels = "leap_one_server"`)
+		return []byte(`{"tickets":["LEAP-1"],"error":null}`), nil
+	}
+	got, err := fetchTicketsByLabel([]string{"for-agents", "leap_one_server"}, nil, runner)
+	require.NoError(t, err)
+	assert.Equal(t, []TicketInput{{ID: "LEAP-1"}}, got)
+}
+
+func TestFetchTicketsByLabel_RunnerError(t *testing.T) {
+	runner := func(prompt string) ([]byte, error) {
+		return nil, fmt.Errorf("claude not found on PATH")
+	}
+	_, err := fetchTicketsByLabel([]string{"bug"}, nil, runner)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "claude query failed")
+	assert.Contains(t, err.Error(), "claude not found on PATH")
+}
+
+func TestFetchTicketsByLabel_EmptyLabels(t *testing.T) {
+	called := false
+	runner := func(prompt string) ([]byte, error) {
+		called = true
+		return nil, nil
+	}
+	_, err := fetchTicketsByLabel(nil, nil, runner)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "at least one label is required")
+	assert.False(t, called, "runner must not be invoked when labels are empty")
+}
+
+func TestFetchTicketsByLabel_WhitespaceOnlyLabels(t *testing.T) {
+	// Whitespace-only labels should be treated as empty after cleaning.
+	runner := func(prompt string) ([]byte, error) {
+		return nil, nil
+	}
+	_, err := fetchTicketsByLabel([]string{"", "   "}, nil, runner)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "at least one label is required")
+}
+
+func TestFetchTicketsByLabel_ZeroMatches(t *testing.T) {
+	runner := func(prompt string) ([]byte, error) {
+		return []byte(`{"tickets":[],"error":null}`), nil
+	}
+	_, err := fetchTicketsByLabel([]string{"bug"}, nil, runner)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no tickets matched")
+}
+
+func TestMatchBalancedBrace(t *testing.T) {
+	tests := []struct {
+		name string
+		buf  string
+		open int
+		want int
+	}{
+		{"simple", `{"a":1}`, 0, 6},
+		{"nested", `{"a":{"b":1}}`, 0, 12},
+		{"brace in string", `{"a":"{}"}`, 0, 9},
+		{"escaped quote in string", `{"a":"\""}`, 0, 9},
+		{"unbalanced", `{"a":1`, 0, -1},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := matchBalancedBrace([]byte(tc.buf), tc.open)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/internal/cmd/batch.go
+++ b/internal/cmd/batch.go
@@ -24,7 +24,14 @@ var (
 	batchFromFlag        string
 	batchDryRunFlag      bool
 	batchProjectFlag     bool
+	batchJiraLabelFlag   []string
+	batchJiraProjectFlag []string
 )
+
+// labelTicketFetcher is the seam used by runBatch to resolve tickets from
+// Jira labels. Production code points it at batch.FetchTicketsByLabel;
+// tests swap it for a canned fetcher.
+var labelTicketFetcher = batch.FetchTicketsByLabel
 
 var batchCmd = &cobra.Command{
 	Use:   "batch [ticket-ids...]",
@@ -37,15 +44,22 @@ Input methods:
   clade batch PROJ-123 PROJ-456 PROJ-789       # Direct ticket IDs
   clade batch --file tickets.csv                # From CSV file
   clade batch --file tickets.txt                # From text file (one per line)
+  clade batch --jira-label bug                  # Fetched from Jira by label
+  clade batch --jira-label bug --jira-project PROJ  # Scoped to projects
 
 CSV files can have a header row with "ticket", "id", or "key" column,
 or just one ticket ID per line.
+
+Label-based fetching delegates to the Atlassian Jira MCP (no Jira
+credentials are handled by clade directly). Inputs from all sources are
+merged and deduplicated.
 
 Examples:
   clade batch SALESPRO-1234 SALESPRO-1235 --concurrency 2
   clade batch --file sprint-tickets.csv --concurrency 3 --repo leap-360
   clade batch PROJ-100 --budget 5.00 --type bug
-  clade batch PROJ-100 --prompt "Fix the bug described in {TICKET_ID}"`,
+  clade batch PROJ-100 --prompt "Fix the bug described in {TICKET_ID}"
+  clade batch --jira-label triage-bug --jira-project SALESPRO,LEAP --dry-run`,
 	Args: cobra.ArbitraryArgs,
 	RunE: runBatch,
 }
@@ -80,10 +94,43 @@ func init() {
 	batchCmd.Flags().StringVarP(&batchFromFlag, "from", "f", "", "Base branch to create from (default: origin's default branch)")
 	batchCmd.Flags().BoolVar(&batchDryRunFlag, "dry-run", false, "Preview what would be created without running")
 	batchCmd.Flags().BoolVar(&batchProjectFlag, "project", false, "Create a clade project per ticket (multi-repo workspace)")
+	batchCmd.Flags().StringSliceVar(&batchJiraLabelFlag, "jira-label", nil, "Comma-separated Jira labels to fetch tickets for (via Atlassian MCP)")
+	batchCmd.Flags().StringSliceVar(&batchJiraProjectFlag, "jira-project", nil, "Comma-separated Jira project keys to scope label search (requires --jira-label)")
+}
+
+// labelFetchInfo captures what was requested from Jira so dry-run output
+// can display it. nil when no label fetching happened.
+type labelFetchInfo struct {
+	Labels   []string
+	Projects []string
+	Resolved int
 }
 
 func runBatch(cmd *cobra.Command, args []string) error {
-	// Collect ticket inputs from args and/or file
+	// Validate Jira label-fetching flag composition up front.
+	//
+	// Cobra's StringSliceVar leaves the backing slice empty when the user
+	// passes --jira-label="" — so slice length alone isn't enough to
+	// distinguish "flag not passed" from "flag passed with empty value."
+	// Flags().Changed reports whether the flag was passed regardless of
+	// value. Tests call runBatch with a nil cmd and set the slice
+	// directly, so we also accept a non-empty slice as evidence.
+	labels := trimStrings(batchJiraLabelFlag)
+	jiraProjects := trimStrings(batchJiraProjectFlag)
+
+	labelExplicit := len(batchJiraLabelFlag) > 0 ||
+		(cmd != nil && cmd.Flags().Changed("jira-label"))
+	projectExplicit := len(batchJiraProjectFlag) > 0 ||
+		(cmd != nil && cmd.Flags().Changed("jira-project"))
+
+	if projectExplicit && !labelExplicit {
+		return fmt.Errorf("--jira-project requires --jira-label")
+	}
+	if labelExplicit && len(labels) == 0 {
+		return fmt.Errorf("--jira-label cannot be empty")
+	}
+
+	// Collect ticket inputs from args and/or file and/or Jira label query.
 	var inputs []batch.TicketInput
 
 	// From CLI args
@@ -100,8 +147,24 @@ func runBatch(cmd *cobra.Command, args []string) error {
 		inputs = append(inputs, fileTickets...)
 	}
 
+	// From Jira label query (MCP-delegated; no Go-side Jira client)
+	var fetchInfo *labelFetchInfo
+	if len(labels) > 0 {
+		ui.Info("Fetching tickets from Jira for labels: %s", strings.Join(labels, ", "))
+		labelTickets, err := labelTicketFetcher(labels, jiraProjects)
+		if err != nil {
+			return fmt.Errorf("jira label fetch failed: %w", err)
+		}
+		fetchInfo = &labelFetchInfo{
+			Labels:   labels,
+			Projects: jiraProjects,
+			Resolved: len(labelTickets),
+		}
+		inputs = append(inputs, labelTickets...)
+	}
+
 	if len(inputs) == 0 {
-		return fmt.Errorf("no ticket IDs provided. Pass them as arguments or use --file")
+		return fmt.Errorf("no ticket IDs provided. Pass them as arguments, use --file, or use --jira-label")
 	}
 
 	// Deduplicate by ticket ID
@@ -138,7 +201,7 @@ func runBatch(cmd *cobra.Command, args []string) error {
 
 	// Dry run
 	if batchDryRunFlag {
-		return printBatchDryRun(inputs, defaultRepoName, defaultRepoPath, labelCfg.BranchPrefix, cfg)
+		return printBatchDryRun(inputs, defaultRepoName, defaultRepoPath, labelCfg.BranchPrefix, cfg, fetchInfo)
 	}
 
 	// Create batch
@@ -457,7 +520,7 @@ func runBatchLogs(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func printBatchDryRun(inputs []batch.TicketInput, defaultRepoName, defaultRepoPath, branchPrefix string, cfg *config.Config) error {
+func printBatchDryRun(inputs []batch.TicketInput, defaultRepoName, defaultRepoPath, branchPrefix string, cfg *config.Config, fetchInfo *labelFetchInfo) error {
 	fmt.Println()
 	fmt.Println(ui.Bold("Dry run - no changes will be made"))
 	fmt.Println()
@@ -465,6 +528,13 @@ func printBatchDryRun(inputs []batch.TicketInput, defaultRepoName, defaultRepoPa
 	ui.KeyValue("Default repo", fmt.Sprintf("%s (%s)", defaultRepoName, defaultRepoPath))
 	ui.KeyValue("Tickets", fmt.Sprintf("%d", len(inputs)))
 	ui.KeyValue("Concurrency", fmt.Sprintf("%d", batchConcurrencyFlag))
+	if fetchInfo != nil {
+		ui.KeyValue("Jira labels", strings.Join(fetchInfo.Labels, ", "))
+		if len(fetchInfo.Projects) > 0 {
+			ui.KeyValue("Jira projects", strings.Join(fetchInfo.Projects, ", "))
+		}
+		ui.KeyValue("Resolved from labels", fmt.Sprintf("%d", fetchInfo.Resolved))
+	}
 	if batchProjectFlag {
 		ui.KeyValue("Mode", "project (multi-repo workspace per ticket)")
 	}
@@ -504,6 +574,19 @@ func printBatchDryRun(inputs []batch.TicketInput, defaultRepoName, defaultRepoPa
 	fmt.Println()
 	fmt.Println(ui.Dim("Remove --dry-run to execute"))
 	return nil
+}
+
+// trimStrings returns a copy of values with whitespace trimmed and empty
+// entries removed.
+func trimStrings(values []string) []string {
+	out := make([]string, 0, len(values))
+	for _, v := range values {
+		v = strings.TrimSpace(v)
+		if v != "" {
+			out = append(out, v)
+		}
+	}
+	return out
 }
 
 func dedupInputs(inputs []batch.TicketInput) []batch.TicketInput {

--- a/internal/cmd/batch_test.go
+++ b/internal/cmd/batch_test.go
@@ -1,0 +1,119 @@
+package cmd
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/daniil-lyalko/clade/internal/batch"
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTrimStrings(t *testing.T) {
+	got := trimStrings([]string{" bug ", "", "urgent", "   "})
+	assert.Equal(t, []string{"bug", "urgent"}, got)
+
+	// Nil input returns empty slice.
+	assert.Empty(t, trimStrings(nil))
+}
+
+// resetBatchFlags clears package-level batch flag state so tests don't
+// leak into each other. Also clears cobra's per-flag Changed bit on
+// batchCmd so tests that drive the flag parser don't influence the next.
+func resetBatchFlags() {
+	batchFileFlag = ""
+	batchJiraLabelFlag = nil
+	batchJiraProjectFlag = nil
+	labelTicketFetcher = batch.FetchTicketsByLabel
+
+	batchCmd.Flags().VisitAll(func(f *pflag.Flag) {
+		f.Changed = false
+	})
+}
+
+func TestRunBatch_JiraProjectWithoutLabel(t *testing.T) {
+	resetBatchFlags()
+	defer resetBatchFlags()
+
+	batchJiraProjectFlag = []string{"PROJ"}
+
+	err := runBatch(nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--jira-project requires --jira-label")
+}
+
+func TestRunBatch_EmptyJiraLabel(t *testing.T) {
+	resetBatchFlags()
+	defer resetBatchFlags()
+
+	// All entries whitespace-only → post-trim, labels are empty.
+	batchJiraLabelFlag = []string{"", "   "}
+
+	err := runBatch(nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--jira-label cannot be empty")
+}
+
+func TestRunBatch_LabelFetchErrorSurfaces(t *testing.T) {
+	resetBatchFlags()
+	defer resetBatchFlags()
+
+	batchJiraLabelFlag = []string{"bug"}
+	labelTicketFetcher = func(labels, projects []string) ([]batch.TicketInput, error) {
+		assert.Equal(t, []string{"bug"}, labels)
+		assert.Empty(t, projects)
+		return nil, fmt.Errorf("mcp unavailable")
+	}
+
+	err := runBatch(nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "jira label fetch failed")
+	assert.Contains(t, err.Error(), "mcp unavailable")
+}
+
+func TestRunBatch_LabelFetcherReceivesTrimmedValues(t *testing.T) {
+	resetBatchFlags()
+	defer resetBatchFlags()
+
+	batchJiraLabelFlag = []string{"  bug  ", "urgent"}
+	batchJiraProjectFlag = []string{"PROJ ", " OTHER"}
+	called := false
+	labelTicketFetcher = func(labels, projects []string) ([]batch.TicketInput, error) {
+		called = true
+		assert.Equal(t, []string{"bug", "urgent"}, labels)
+		assert.Equal(t, []string{"PROJ", "OTHER"}, projects)
+		return nil, fmt.Errorf("stop here") // short-circuit the rest
+	}
+
+	_ = runBatch(nil, nil)
+	assert.True(t, called, "fetcher must be invoked with trimmed labels/projects")
+}
+
+// TestRunBatch_EmptyJiraLabelViaCobra drives the cobra flag parser directly
+// to exercise the real user-facing path: `clade batch --jira-label ""`.
+// Cobra leaves the backing slice empty in this case, so the check relies
+// on Flags().Changed rather than slice length.
+func TestRunBatch_EmptyJiraLabelViaCobra(t *testing.T) {
+	resetBatchFlags()
+	defer resetBatchFlags()
+
+	err := batchCmd.ParseFlags([]string{"--jira-label", ""})
+	require.NoError(t, err)
+
+	err = runBatch(batchCmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--jira-label cannot be empty")
+}
+
+func TestRunBatch_JiraProjectWithoutLabelViaCobra(t *testing.T) {
+	resetBatchFlags()
+	defer resetBatchFlags()
+
+	err := batchCmd.ParseFlags([]string{"--jira-project", "PROJ"})
+	require.NoError(t, err)
+
+	err = runBatch(batchCmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--jira-project requires --jira-label")
+}


### PR DESCRIPTION
## What

Adds two new flags to `clade batch`:

- `--jira-label <labels>` — comma-separated Jira labels. When set, clade resolves matching ticket IDs via the Atlassian Jira MCP and feeds them into the existing ticket input pipeline. **Multiple labels use AND semantics** (a ticket must carry all of them to match).
- `--jira-project <keys>` — comma-separated Jira project keys scoping the search (OR-scoped). Requires `--jira-label`; used alone returns a clear error.

All input sources (positional args, `--file`, `--jira-label`) compose — inputs are merged and deduplicated. `--dry-run` resolves and prints the matched tickets without dispatching work.

## Why

The existing batch pipeline assumes you already know the ticket IDs you want to process. In practice, sprint work often starts from a Jira label (e.g. `for-agents`, `triage-bug`) rather than a hand-curated list. Label-based fetching closes that gap without pulling Jira credentials into clade — the query is delegated to the MCP that's already configured for the per-ticket agents.

The AND semantics on multiple labels enables a simple convention for routing tickets to the right repo when you have several registered:

```bash
# In Jira, tag tickets meant for leap_one_server with BOTH `for-agents` and `leap_one_server`.
clade batch --jira-label for-agents,leap_one_server -r leap_one_server
clade batch --jira-label for-agents,salespro       -r salespro
```

Each invocation pulls only the tickets tagged for that specific repo.

## Design

**In-pattern with existing batch.** The batch feature already delegates Jira interaction to Claude via the Atlassian MCP (see `batch.go:376-412` on main — agents fetch tickets with `getJiraIssue`). This PR extends the same pattern to the CLI itself: for label queries, clade runs `claude -p <prompt>` as a one-shot, parses a strict JSON reply, and returns the resolved ticket IDs. No Go-side Jira HTTP client. No credential handling in clade. No new config.

**Response contract.** The prompt instructs Claude to emit a single JSON line: `{"tickets":["KEY-1","KEY-2"],"error":null}`. Parsing is tolerant of prose before/after and falls back to balanced-brace extraction if Claude pretty-prints the JSON across multiple lines.

**JQL semantics.** Labels AND'd (each becomes its own `labels = "X"` clause), projects OR'd (`project in (...)`). This matches user intuition: "narrow further with each label" for labels, "in any of these projects" for projects.

**Flag-name collision resolution.** `--project` already exists on `clade batch` as a bool meaning "create a clade multi-repo workspace per ticket." Rather than overload or rename, the Jira filter is explicitly named `--jira-project`, pairing with `--jira-label`. No breaking changes.

**Validation.** Uses `cmd.Flags().Changed(...)` so `--jira-label ""` surfaces a clean "--jira-label cannot be empty" error instead of falling through to a generic "no ticket IDs" message.

## Testing

- **27 new tests** across `internal/batch/jira_labels_test.go` and `internal/cmd/batch_test.go`:
  - JQL construction: single/multi label + optional projects, AND semantics verification, quoted values with spaces, whitespace handling.
  - Parse robustness: clean JSON, JSON wrapped in prose, JSON in code fences, **multi-line pretty-printed JSON (balanced-brace fallback)**, error field set, zero matches, no JSON at all, unrelated JSON ignored, ID trimming, all-empty IDs rejected, >64KB buffer.
  - Fetcher seam (runner-injected): happy path, runner error, empty-label guard, zero-match error surfacing, trimmed labels/projects passed through, multiple-labels-AND verification.
  - Flag composition via cobra's real parser: `--jira-project` alone → error; empty `--jira-label ""` → error; fetcher errors surface cleanly.
- **Coverage:** `internal/batch` package at 83%+ (core logic at 100%; the uncovered seams are the public wrapper and the `exec.Command` boundary).
- Existing CSV/file-input tests unchanged — regression coverage for the untouched CSV flow is preserved.
- `go vet`, `gofmt` clean on all modified/new files.
- **Manually verified** against a real Atlassian Jira MCP: dry-run resolves tickets for `--jira-label for-agents,<repo> --jira-project <PROJ>`, composition errors fire correctly, zero-match produces clear messaging with the JQL in the error.

## Documentation

- **`USER_GUIDE.md`** — new end-to-end `clade batch` section (previously the feature was documented only via `--help`). Covers all flags, input sources, CSV format, subcommands, label semantics, and a new "Routing tickets to repos via labels" sub-section plus "Scenario 5: Batch-process tickets by Jira label (with per-repo routing)" workflow walkthrough.
- **`README.md`** — new "Batch mode" block in the Commands section with a link into the detailed guide.
- **`CLAUDE.md`** — batch entries added to the Quick Reference.
- **`CHANGELOG.md`** — `[Unreleased]` entry covering the flags, AND semantics, and the routing pattern.

## Future work (not in this PR)

- **Per-ticket repo metadata from Jira.** Today, label fetching assigns every resolved ticket to the default `-r`. A future change could have Claude return `{id, repo}` populated from a Jira custom field (e.g. "Repository"), which would populate `TicketInput.Repos` the way the CSV `repos` column does. Would let a single batch invocation span repos without the per-repo convention.
- Timeout / SIGINT handling for the `claude -p` MCP query (currently inherits the same limitations tracked in v0.7.0's "Known Limitations").
- Retry-on-transient-error for the Jira MCP query.
- Optional label resolution from a different issue tracker MCP (GitHub Issues, Linear) if the project expands beyond Jira.

## Credits

Builds on prior work by **Daniil** (clade) and **Robert** (batch mode in PR #17). This PR is a small extension on top of their foundation.